### PR TITLE
refactor: createBrowserRouter 사용하도록 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import Login from '@/pages/Login';
 import Home from '@/pages/Home';
 import CafeSearch from '@/pages/CafeSearch';
@@ -6,19 +6,17 @@ import WriteReview from '@/pages/WriteReview';
 import CafeInfo from '@/pages/CafeInfo';
 import MyPage from '@/pages/MyPage';
 
+const router = createBrowserRouter([
+  { path: "/login", element: <Login /> },
+  { path: "/", element: <Home /> },
+  { path: "/search", element: <CafeSearch /> },
+  { path: "/review/write", element: <WriteReview /> },
+  { path: "/cafe/:id", element: <CafeInfo /> },
+  { path: "/mypage", element: <MyPage /> },
+]);
+
 function App() {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/login" element={<Login />} />
-        <Route path="/" element={<Home />} />
-        <Route path="/search" element={<CafeSearch />} />
-        <Route path="/review/write" element={<WriteReview />} />
-        <Route path="/cafe/:id" element={<CafeInfo />} />
-        <Route path="/mypage" element={<MyPage />} />
-      </Routes>
-    </Router>
-  );
+  return <RouterProvider router={router} />;
 }
 
 export default App;


### PR DESCRIPTION
## 변경사항
createBrowserRouter가 기본적인 라우터로 권장된다고 합니다. 데이터 로딩, 폴백 UI, 에러 핸들링 등을 라우터 레벨에서 선언적으로 처리할 수 있는 API를 제공하여 라우트마다 개별적인 설정이 가능하고 라우트 설정을 개별적으로 분리하여 관리할 수 있기 때문에 추후 최적화나 에러처리를 고려하여 변경하겠습니다.