### PR TITLE
feat: 헤더 컴포넌트에 오른쪽 요소 추가 기능 구현

### DIFF
--- a/src/app/layout/header/Header.module.scss
+++ b/src/app/layout/header/Header.module.scss
@@ -52,4 +52,18 @@
     color: #111827;
     margin: 0;
   }
+
+  .rightElement {
+    position: absolute;
+    right: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .completeButton {
+    @include mixins.apply-text-style(b1_bold);
+    background: none;
+    border: none;
+  }
 }

--- a/src/app/layout/header/Header.tsx
+++ b/src/app/layout/header/Header.tsx
@@ -5,9 +5,10 @@ import backIcon from '@shared/assets/images/common/back.svg';
 interface HeaderProps {
   showBackButton?: boolean;
   title?: string;
+  rightElement?: React.ReactNode;
 }
 
-const Header = ({ showBackButton = true, title }: HeaderProps) => {
+const Header = ({ showBackButton = true, title, rightElement }: HeaderProps) => {
   const navigate = useNavigate();
 
   return (
@@ -22,6 +23,11 @@ const Header = ({ showBackButton = true, title }: HeaderProps) => {
           </button>
         )}
         {title && <h1 className={styles.title}>{title}</h1>}
+        {rightElement && (
+          <div className={styles.rightElement}>
+            {rightElement}
+          </div>
+        )}
       </div>
     </header>
   );

--- a/src/app/layout/mainLayout/MainLayout.module.scss
+++ b/src/app/layout/mainLayout/MainLayout.module.scss
@@ -1,7 +1,8 @@
 .mainContent {
   min-height: 100vh;
+  padding-top: calc(var(--header-height) + 6px);
 
   &.withHeader {
-    padding-top: calc(var(--header-height) + 6px);
+    // 필요한 경우 스타일 추가
   }
 }

--- a/src/app/layout/mainLayout/MainLayout.tsx
+++ b/src/app/layout/mainLayout/MainLayout.tsx
@@ -9,6 +9,7 @@ interface MainLayoutProps {
   showFooter?: boolean;
   showBackButton?: boolean;
   headerTitle?: string;
+  rightElement?: React.ReactNode;
 }
 
 const MainLayout = ({ 
@@ -16,14 +17,16 @@ const MainLayout = ({
   showHeader = true, 
   showFooter = true, 
   showBackButton = true,
-  headerTitle = '' 
+  headerTitle = '',
+  rightElement
 }: MainLayoutProps) => {
   return (
     <div>
       {showHeader && (
         <Header 
           title={headerTitle}
-          showBackButton={showBackButton} 
+          showBackButton={showBackButton}
+          rightElement={rightElement}
         />
       )}
       <main className={`${styles.mainContent} ${showHeader ? styles.withHeader : ''}`}>

--- a/src/app/routers/appRouter.tsx
+++ b/src/app/routers/appRouter.tsx
@@ -1,108 +1,128 @@
 import {
-    createBrowserRouter,
-    createRoutesFromElements,
-    Link,
-    Outlet,
-    Route,
-    RouterProvider,
-} from 'react-router-dom'
-import MainLayout from '@app/layout/mainLayout/MainLayout'
-import Login from '@/pages/Login'
+  createBrowserRouter,
+  createRoutesFromElements,
+  Link,
+  Outlet,
+  Route,
+  RouterProvider,
+} from "react-router-dom";
+import MainLayout from "@app/layout/mainLayout/MainLayout";
+import Login from "@/pages/Login";
 import ReviewList from "@/pages/ReviewList";
-import CafeSearch from '@/pages/CafeSearch'
-import WriteReview from '@/pages/WriteReview'
-import CafeInfo from '@/pages/CafeInfo'
-import MyPage from '@/pages/MyPage'
-import { ProtectedRoute } from '@app/routers/ProtectedRoute'
+import CafeSearch from "@/pages/CafeSearch";
+import WriteReview from "@/pages/WriteReview";
+import CafeInfo from "@/pages/CafeInfo";
+import MyPage from "@/pages/MyPage";
+import { ProtectedRoute } from "@app/routers/ProtectedRoute";
+import styles from "@app/layout/header/Header.module.scss";
 
 export const AppRouter = () => {
-    const routes = createRoutesFromElements(
-        <Route path='/' element={<Outlet />}>
-            <Route path='login' element={
-                <MainLayout
-                    showHeader={false}
-                    showFooter={false}
-                    showBackButton={false}
-                    headerTitle="로그인"
+  const routes = createRoutesFromElements(
+    <Route path="/" element={<Outlet />}>
+      <Route
+        path="login"
+        element={
+          <MainLayout
+            showHeader={false}
+            showFooter={false}
+            showBackButton={false}
+            headerTitle="로그인"
+          >
+            <Login />
+          </MainLayout>
+        }
+      />
+
+      <Route
+        element={
+          <ProtectedRoute>
+            <Outlet />
+          </ProtectedRoute>
+        }
+      >
+        <Route
+          index
+          element={
+            <MainLayout
+              showHeader={false}
+              showFooter={true}
+              showBackButton={false}
+              headerTitle="리뷰 목록"
+            >
+              <ReviewList />
+            </MainLayout>
+          }
+          handle={{ crumb: <Link to="/">ReviewList</Link> }}
+        />
+        <Route
+          path="search"
+          element={
+            <MainLayout
+              showHeader={true}
+              showFooter={true}
+              showBackButton={true}
+              headerTitle="장소 검색"
+              rightElement={
+                <button
+                  className={styles.completeButton}
+                  onClick={() => {
+                    /* 이벤트 처리 */
+                  }}
                 >
-                    <Login />
-                </MainLayout>
-            } />
+                  완료
+                </button>
+              }
+            >
+              <CafeSearch />
+            </MainLayout>
+          }
+          handle={{ crumb: <Link to="/search">카페 검색</Link> }}
+        />
+        <Route
+          path="review/write"
+          element={
+            <MainLayout
+              showHeader={true}
+              showFooter={false}
+              showBackButton={true}
+              headerTitle="리뷰 작성"
+            >
+              <WriteReview />
+            </MainLayout>
+          }
+          handle={{ crumb: <Link to="/review/write">리뷰 작성</Link> }}
+        />
+        <Route
+          path="cafe/:id"
+          element={
+            <MainLayout
+              showHeader={true}
+              showFooter={true}
+              showBackButton={true}
+              headerTitle="카페 정보"
+            >
+              <CafeInfo />
+            </MainLayout>
+          }
+          handle={{ crumb: <Link to="/cafe">카페 정보</Link> }}
+        />
+        <Route
+          path="mypage"
+          element={
+            <MainLayout
+              showHeader={true}
+              showFooter={true}
+              showBackButton={true}
+              headerTitle="마이페이지"
+            >
+              <MyPage />
+            </MainLayout>
+          }
+          handle={{ crumb: <Link to="/mypage">마이페이지</Link> }}
+        />
+      </Route>
+    </Route>
+  );
 
-            <Route element={<ProtectedRoute><Outlet /></ProtectedRoute>}>
-                <Route 
-                    index 
-                    element={
-                        <MainLayout 
-                            showHeader={false}
-                            showFooter={true}
-                            showBackButton={false}
-                            headerTitle="리뷰 목록"
-                        >
-                            <ReviewList />
-                        </MainLayout>
-                    }
-                    handle={{ crumb: <Link to='/'>ReviewList</Link> }}
-                />
-                <Route
-                    path='search'
-                    element={
-                        <MainLayout
-                            showHeader={true}
-                            showFooter={true}
-                            showBackButton={true}
-                            headerTitle="장소 검색"
-                        >
-                            <CafeSearch />
-                        </MainLayout>
-                    }
-                    handle={{ crumb: <Link to='/search'>카페 검색</Link> }}
-                />
-                <Route
-                    path='review/write'
-                    element={
-                        <MainLayout
-                            showHeader={true}
-                            showFooter={false}
-                            showBackButton={true}
-                            headerTitle="리뷰 작성"
-                        >
-                            <WriteReview />
-                        </MainLayout>
-                    }
-                    handle={{ crumb: <Link to='/review/write'>리뷰 작성</Link> }}
-                />
-                <Route
-                    path='cafe/:id'
-                    element={
-                        <MainLayout
-                            showHeader={true}
-                            showFooter={true}
-                            showBackButton={true}
-                            headerTitle="카페 정보"
-                        >
-                            <CafeInfo />
-                        </MainLayout>
-                    }
-                    handle={{ crumb: <Link to='/cafe'>카페 정보</Link> }}
-                />
-                <Route
-                    path='mypage'
-                    element={
-                        <MainLayout
-                            showHeader={true}
-                            showFooter={true}
-                            showBackButton={true}
-                            headerTitle="마이페이지"
-                        >
-                            <MyPage />
-                        </MainLayout>
-                    }
-                    handle={{ crumb: <Link to='/mypage'>마이페이지</Link> }}
-                />
-            </Route>
-        </Route>
-    );
-
-    return <RouterProvider router={createBrowserRouter(routes)} />;
+  return <RouterProvider router={createBrowserRouter(routes)} />;
 };


### PR DESCRIPTION
## 변경사항
- Header 컴포넌트에 rightElement prop 추가하여 오른쪽 영역에 요소를 추가할 수 있는 기능
- showHeader = false인 경우에도 항상 헤더 공간을 차지하도록 css 변경

> [!IMPORTANT]  
> 검색 페이지에 테스트용 버튼을 하나 두었는데 좋지 못한 방법으로 추가되어 있습니다.
> non-component, 버튼 스타일이 Header.module.scss에 정의, 나중에 제거 필요합니다.