### PR TITLE
feat: CafeSearch 페이지 진입 경로별 네비게이션 분기 처리

### DIFF
--- a/src/app/layout/footer/Footer.tsx
+++ b/src/app/layout/footer/Footer.tsx
@@ -1,8 +1,8 @@
-import { useNavigate } from 'react-router-dom';
-import styles from './Footer.module.scss';
-import homeIcon from '@shared/assets/images/nav/home.svg';
-import searchIcon from '@shared/assets/images/nav/search.svg';
-import profileIcon from '@shared/assets/images/nav/profile.svg';
+import { useNavigate } from "react-router-dom";
+import styles from "./Footer.module.scss";
+import homeIcon from "@shared/assets/images/nav/home.svg";
+import searchIcon from "@shared/assets/images/nav/search.svg";
+import profileIcon from "@shared/assets/images/nav/profile.svg";
 
 const Footer = () => {
   const navigate = useNavigate();
@@ -10,19 +10,22 @@ const Footer = () => {
   return (
     <footer className={styles.footer}>
       <nav className={styles.nav}>
-        <div onClick={() => navigate('/')} className={styles.navItem}>
+        <div onClick={() => navigate("/")} className={styles.navItem}>
           <button className={styles.navButton}>
             <img src={homeIcon} alt="홈" />
             <span>홈</span>
           </button>
         </div>
-        <div onClick={() => navigate('/search')} className={styles.navItem}>
-          <button className={styles.navButton}>
+        <div className={styles.navItem}>
+          <button
+            onClick={() => navigate("/search", { state: { from: "footer" } })}
+            className={styles.navButton}
+          >
             <img src={searchIcon} alt="검색" />
             <span>검색</span>
           </button>
         </div>
-        <div onClick={() => navigate('/mypage')} className={styles.navItem}>
+        <div onClick={() => navigate("/mypage")} className={styles.navItem}>
           <button className={styles.navButton}>
             <img src={profileIcon} alt="프로필" />
             <span>프로필</span>

--- a/src/entities/cafeListItem/CafeListItem.tsx
+++ b/src/entities/cafeListItem/CafeListItem.tsx
@@ -1,36 +1,20 @@
-import { useNavigate } from 'react-router-dom';
-import { useReviewDraftStore } from '@shared/store/useReviewDraftStore';
 import type { ICafeDescription } from '@shared/api/cafe/types';
 import styles from "./CafeListItem.module.scss";
 import defaultProfile from "@shared/assets/images/cafe/profile.svg";
 
-type CafeListItemProps = ICafeDescription;
+interface CafeListItemProps extends ICafeDescription {
+  onSelect: () => void;
+}
 
 const CafeListItem = ({
   name,
   address,
   profileImg,
-  ...cafeInfo
+  onSelect,
 }: CafeListItemProps) => {
-  const navigate = useNavigate();
-  const { updateDraft } = useReviewDraftStore();
-
-  // 검색에서 카페 선택 시 카페 정보를 Draft에 저장하고 리뷰 작성 페이지로 이동
-  const handleClick = () => {
-    updateDraft({ 
-      cafe: { 
-        name, 
-        address, 
-        profileImg, 
-        ...cafeInfo 
-      } 
-    });
-    navigate('/review/write');
-  };
-
   return (
     <li className={styles.cafeItem}>
-      <a onClick={handleClick} className={styles.cafeItem__link}>
+      <a onClick={onSelect} className={styles.cafeItem__link}>
         <div className={styles.cafeItem__imageWrapper}>
           <img
             src={profileImg || defaultProfile}

--- a/src/shared/api/cafe/types.ts
+++ b/src/shared/api/cafe/types.ts
@@ -4,6 +4,7 @@ interface ICoordinate {
 }
 
 export interface ICafeDescription {
+    readonly id: string
     readonly image?: string[]
     readonly name: string
     readonly location: ICoordinate

--- a/src/widgets/cafeList/ui/CafeList.tsx
+++ b/src/widgets/cafeList/ui/CafeList.tsx
@@ -4,14 +4,16 @@ import type { ICafeDescription } from "@shared/api/cafe/types";
 
 interface CafeListProps {
   cafeInfo: ICafeDescription[];
+  onCafeSelect: (cafe: ICafeDescription) => void;
 }
 
-export const CafeList = ({ cafeInfo }: CafeListProps) => (
+export const CafeList = ({ cafeInfo, onCafeSelect }: CafeListProps) => (
   <ul className={styles.cafeList}>
     {cafeInfo.map((cafe) => (
       <CafeItem
-        key={cafe.name}
+        key={cafe.id}
         {...cafe}
+        onSelect={() => onCafeSelect(cafe)}
       />
     ))}
   </ul>


### PR DESCRIPTION
## 변경사항
- Footer의 검색 버튼 클릭 시 state에 진입 경로 정보 추가 
- CafeListItem 컴포넌트 리팩토링
  - 카페 선택 핸들러를 props로 받도록 변경 (`onSelect`)
  - 불필요한 props spreading 제거
- CafeSearch 페이지 개선
  - 진입 경로(`footer`)에 따른 네비게이션 분기 처리
    - Footer에서 진입: 카페 상세 페이지로 이동 (`/cafe/{id}`)
    - 기타 경로: 리뷰 작성 페이지로 이동 (`/review/write`)

## Todo
- 검색 결과에 카페 id가 포함되어 있지 않아 아래와 같은 흐름을 참고하여 id를 획득하는 로직을 작성해야 합니다.
  - 카페 상세 페이지로 이동할 경우 필요한 id값은 다음과 같은 방법으로 생성됩니다.
    1. 카페 검색 결과 네이버 api 사용해서 백엔드에서 전송됨
    2. 해당 결과에 카페 id는 없음
    3. 카페 선택
    4. 카페 저장여부 조회 api(카페명, mapx, mapy) 사용해서 db 저장여부 확인 -> 저장되어 있는 경우 카페 id가 반환되며 그것을 사용합니다. 저장이 되어있지 않으면 다음 항목으로 진행합니다.
    5. 저장이 안되어있으면 카페 저장 POST 요청 -> 요청이 성공하면 카페 id가 반환됩니다.
    6. 카페 id로 단일 조회