### PR TITLE
feat: 리뷰 작성완료 시 작성 버튼을 클릭했던 페이지로 이동

### DIFF
--- a/src/app/layout/footer/Footer.tsx
+++ b/src/app/layout/footer/Footer.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { useNavigationStore } from "@shared/store/useNavigationStore";
 import styles from "./Footer.module.scss";
 import homeIcon from "@shared/assets/images/nav/home.svg";
 import searchIcon from "@shared/assets/images/nav/search.svg";
@@ -6,6 +7,12 @@ import profileIcon from "@shared/assets/images/nav/profile.svg";
 
 const Footer = () => {
   const navigate = useNavigate();
+  const { setIsFromFooter } = useNavigationStore();
+
+  const handleSearchClick = () => {
+    setIsFromFooter(true);
+    navigate("/search");
+  };
 
   return (
     <footer className={styles.footer}>
@@ -18,7 +25,7 @@ const Footer = () => {
         </div>
         <div className={styles.navItem}>
           <button
-            onClick={() => navigate("/search", { state: { from: "footer" } })}
+            onClick={handleSearchClick}
             className={styles.navButton}
           >
             <img src={searchIcon} alt="검색" />

--- a/src/pages/CafeSearch.tsx
+++ b/src/pages/CafeSearch.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { useSearchParams, useLocation, useNavigate } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { CafeList } from "@widgets/cafeList";
 import { SearchBar } from "@features/search/ui/SearchBar";
 import { searchCafes } from "@shared/api/cafe/cafeSearch";
 import { useReviewDraftStore } from "@shared/store/useReviewDraftStore";
+import { useNavigationStore } from "@shared/store/useNavigationStore";
 import type { ICafeDescription } from "@shared/api/cafe/types";
 import styles from "./styles/CafeSearch.module.scss";
 
@@ -13,16 +14,16 @@ const CafeSearch = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const location = useLocation();
   const navigate = useNavigate();
   const { updateDraft } = useReviewDraftStore();
-  const isFromFooter = location.state?.from === 'footer';
+  const { returnPath, setReturnPath, isFromFooter, setIsFromFooter } = useNavigationStore();
 
   const handleCafeSelect = (cafe: ICafeDescription) => {
     if (isFromFooter) {
-      // state를 제거하기 위해 replace: true 옵션 사용
-      navigate(`/cafe/${cafe.id}`, { replace: true });
+      setIsFromFooter(false); // cleanup
+      navigate(`/cafe/${cafe.id}`);
     } else {
+      setReturnPath(returnPath || "/"); // 이전 경로가 없으면 홈으로
       updateDraft({ 
         cafe: {
           id: cafe.id,

--- a/src/pages/WriteReview.tsx
+++ b/src/pages/WriteReview.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+import { useNavigationStore } from '@shared/store/useNavigationStore';
 import { StarRating } from "@widgets/starRating";
 import { DatePicker } from "@widgets/datePicker";
 import { useReviewDraftStore } from "@shared/store/useReviewDraftStore";
@@ -38,6 +40,8 @@ const TAGS = {
 };
 
 const WriteReview = () => {
+  const navigate = useNavigate();
+  const returnPath = useNavigationStore((state) => state.returnPath);
   const { draft, updateDraft, clearDraft } = useReviewDraftStore();
 
   useEffect(() => {
@@ -50,6 +54,15 @@ const WriteReview = () => {
       clearDraft();
     }
   }, [clearDraft]);
+
+  const handleSubmit = () => {
+    // TODO: API 호출
+    if (returnPath) {
+      navigate(returnPath, { replace: true });
+    } else {
+      navigate('/', { replace: true });
+    }
+  };
 
   const handleDateChange = (date: string) => {
     updateDraft({ visitDate: date });
@@ -151,7 +164,7 @@ const WriteReview = () => {
       <div className={styles.buttonOverlay} />
       <button 
         className={styles.submitButton}
-        onClick={() => {/* TODO: 리뷰 제출 로직 */}}
+        onClick={handleSubmit}
         disabled={!draft.visitDate || !draft.rating}
       >
         작성 완료

--- a/src/shared/store/useNavigationStore.ts
+++ b/src/shared/store/useNavigationStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+interface NavigationStore {
+  returnPath: string | null;
+  isFromFooter: boolean;
+  setReturnPath: (path: string | null) => void;
+  setIsFromFooter: (value: boolean) => void;
+}
+
+export const useNavigationStore = create<NavigationStore>((set) => ({
+  returnPath: null,
+  isFromFooter: false,
+  setReturnPath: (path) => set({ returnPath: path }),
+  setIsFromFooter: (value) => set({ isFromFooter: value }),
+}));

--- a/src/shared/ui/floatingButton/FloatingButton.tsx
+++ b/src/shared/ui/floatingButton/FloatingButton.tsx
@@ -1,17 +1,21 @@
 import { useNavigate } from 'react-router-dom';
+import { useNavigationStore } from "@shared/store/useNavigationStore";
 import writeButtonIcon from '@shared/assets/images/write_button.svg';
 import styles from './FloatingButton.module.scss';
 
 const FloatingButton = () => {
   const navigate = useNavigate();
+    const { setReturnPath } = useNavigationStore();
+  
+    const handleButtonClick = () => {
+      setReturnPath(location.pathname);
+      navigate("/search");
+    };
 
   return (
     <button 
       className={styles.floatingButton}
-      onClick={() => navigate("/search", { 
-        state: { from: "footer" },
-        replace: true 
-      })}
+      onClick={handleButtonClick}
       aria-label="카페 검색하기"
     >
       <img src={writeButtonIcon} alt="카페 검색" />


### PR DESCRIPTION
## 변경사항
- 리뷰 작성 완료 시 클릭한 페이지로 다시 돌아가는 Navigation 기능을 구현
  - Navigation 상태 관리를 위한 useNavigationStore 추가
  - returnPath: 리뷰 작성 완료 후 돌아갈 경로
  - FloatingButton 클릭 시 현재 경로를 returnPath로 저장
  - CafeSearch에서 카페 선택 시 isFromFooter 상태에 따른 분기 처리

- WriteReview 페이지에서 작성 완료 시 처리
  - 저장된 returnPath로 이동 (없을 경우 홈으로)