### PR TITLE
feat: Hot Module Replacement(HMR) 유지 및 원격 백엔드 연동을 위한 Vite 환경 설정 개선

### DIFF
--- a/.env.remote
+++ b/.env.remote
@@ -1,0 +1,1 @@
+VITE_APP_REMOTE=true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "dev:remote": "vite --host --mode remote",
     "dev": "vite --host",
     "server": "tsx watch server/index.ts",
     "both": "concurrently \"npm run dev\" \"npm run server\"",

--- a/src/app/auth/useAuthStore.ts
+++ b/src/app/auth/useAuthStore.ts
@@ -14,9 +14,9 @@ export const useAuthStore = create<AuthStore>((set) => ({
   isAuthenticated: false,
   
   login: async (provider: string) => {
-    console.log('Development mode:', import.meta.env.DEV)
-    if (import.meta.env.DEV) {
-      // 개발 모드에서는 MSW로 처리
+    console.log('Remote mode:', import.meta.env.VITE_APP_REMOTE)
+    if (!import.meta.env.VITE_APP_REMOTE) {
+      // MSW 모드
       try {
         console.log('Sending request to MSW endpoint:', `/api/auth/${provider}/login`)
         await apiInstance.get(`/api/auth/${provider}/login`)
@@ -25,7 +25,7 @@ export const useAuthStore = create<AuthStore>((set) => ({
         console.error('로그인 실패:', error)
       }
     } else {
-      // 운영 모드에서는 리다이렉트
+      // 리모트 또는 운영 모드
       console.log('Redirecting to:', `${AUTH_URL}/${provider}`)
       window.location.href = `${AUTH_URL}/${provider}`
     }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import App from "@app/App.tsx";
 import "./app/styles/main.scss";
 
 async function enableMocking() {
-  if (import.meta.env.DEV) {
+  if (!import.meta.env.VITE_APP_REMOTE) {
     const { worker } = await import('./mocks/browser')
     return worker.start()
   }

--- a/src/shared/api/base.ts
+++ b/src/shared/api/base.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
 
-export const API_URL = import.meta.env.DEV ? '' : 'https://packetbreeze.com:8443'
+export const API_URL = import.meta.env.VITE_APP_REMOTE ? 'https://packetbreeze.com:8443' : ''
 export const NAVER_API_URL = 'https://openapi.naver.com/v1'
 export const AUTH_URL = `${API_URL}/oauth2/authorization`
 

--- a/src/shared/api/cafe/cafeSearch.ts
+++ b/src/shared/api/cafe/cafeSearch.ts
@@ -1,9 +1,6 @@
 import { useApi, ApiError } from "@shared/api/hooks/useApi";
 import type { INaverLocalApiResponse, ICafeDescription } from '@shared/api/cafe/types';
-import { dummyCafes } from './mockData';
 import { CafeMapper } from '@shared/api/cafe/mapper/cafeMapper';
-
-const isDevelopment = import.meta.env.DEV;
 
 interface SearchResponse {
   items: INaverLocalApiResponse[]
@@ -47,9 +44,6 @@ export const useCafeSearch = (): CafeSearchHook => {
       return [];
     } catch (error) {
       console.error('카페 검색 중 오류 발생:', error);
-      if (isDevelopment) {
-        return dummyCafes;
-      }
       throw error;
     }
   };

--- a/src/shared/api/images/index.ts
+++ b/src/shared/api/images/index.ts
@@ -13,7 +13,7 @@ export const useImageApi = () => {
       const formData = new FormData();
       formData.append("file", file);
       const response = await post<ImageUploadResponse>(
-        `${BASE_URL}/`, 
+        `${BASE_URL}`, 
         formData,
         {
           headers: {

--- a/src/shared/api/images/index.ts
+++ b/src/shared/api/images/index.ts
@@ -1,8 +1,9 @@
 import { useCallback, useMemo } from "react";
 import { useApi } from "@shared/api/hooks/useApi";
+import { API_URL } from '../base';
 import type { ImageApiResponse, ImageUploadResponse, ImageDeleteResponse } from "./types";
 
-const BASE_URL = "/api/images";
+const BASE_URL = `${API_URL}/api/images`;
 
 export const useImageApi = () => {
   const { post, remove } = useApi<ImageApiResponse>();

--- a/src/shared/api/reviews/reviewApi.ts
+++ b/src/shared/api/reviews/reviewApi.ts
@@ -12,7 +12,7 @@ export const useReviewApi = () => {
     }
   ) => {
     try {
-      const response = await post('/api/reviews', request, {}, {
+      const response = await post('/api/reviews/', request, {}, {
         onSuccess: options?.onSuccess,
         onError: options?.onError
       });


### PR DESCRIPTION
## 변경사항
- 개발환경(npm run dev)의 Hot Module Replacement(HMR)을 유지하면서 원격 백엔드 서버로 요청/응답을 하기 위한 설정
  - .env.remote 파일 생성 및 VITE_APP_REMOTE 플래그 설정
  - package.json에 dev:remote 스크립트 추가 (vite --host --mode remote)
  - MSW 모드 전환 조건 변경(VITE_APP_REMOTE == false)
  - import.meta.env.DEV 대신 import.meta.env.VITE_APP_REMOTE 기반으로 분기 처리

## 변경사유
 - Vite는 기본적으로 개발 서버 실행 시 import.meta.env.DEV를 강제로 true로 설정합니다.
 - 이를 우회하기 위해 별도의 VITE_APP_REMOTE 환경 변수를 도입했습니다.

## 개발 환경
 - npm run dev: 로컬 개발(MSW 활성화)
 - npm run dev:remote: 서버 API 연동 개발(실제 API 호출)

## Todo
 - 백엔드 서버 안정화 후 상시연결 가능하도록 하겠습니다.