### PR TITLE
style: 프로필헤더 축소 로직 변경

### DIFF
--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -18,11 +18,11 @@ const MyPage = () => {
 
     const handleScroll = throttle(() => {
       const scrollTop = mainContent.scrollTop;
-      
-      if (!isScrolled && scrollTop > 80) {
+
+      if (!isScrolled && scrollTop > 156) {
         const oldHeight = headerRef.current?.offsetHeight || 0;
         setIsScrolled(true);
-        
+
         // 헤더 축소 후 스크롤 위치 보정하기
         requestAnimationFrame(() => {
           const newHeight = headerRef.current?.offsetHeight || 0;
@@ -31,7 +31,7 @@ const MyPage = () => {
             mainContent.scrollTop += heightDiff;
           }
         });
-      } else if (isScrolled && scrollTop < 10) {
+      } else if (isScrolled && scrollTop < 76) {
         setIsScrolled(false);
       }
     }, 100);
@@ -48,7 +48,13 @@ const MyPage = () => {
       <div ref={headerRef}>
         <ProfileHeader isScrolled={isScrolled} />
       </div>
-      <div ref={contentRef} style={{ paddingTop: isScrolled ? "84px" : "252px" }}>
+      <div
+        ref={contentRef}
+        style={{
+          // paddingTop: isScrolled ? "84px" : "252px",
+          paddingTop: "252px",
+        }}
+      >
         <FilterBtn />
         <ReviewList type="my" params={{ limit: 10 }} />
         <button onClick={openModal}>Open Modal</button>


### PR DESCRIPTION
## 변경사항
- 프로필헤더 축소/확장 트리거 스크롤 경계값 조정
  - 축소: 80px → 156px
  - 확장: 10px → 76px
- 컨텐츠 영역 상단 패딩 로직 변경
  - 기존: 스크롤 상태에 따라 84px/252px 동적 변경
  - 변경: 252px로 고정

## 변경사유
- 부자연스러운 스크롤 점핑 및 점핑 시 하단에 충분한 영역이 없을때 발생하는 버그를 수정하기 위해 컨텐츠 영역 상단 패딩 로직 변경