### PR TITLE
fix: ProfileHeader 포인터 이벤트가 하위로 전파되도록 설정

### DIFF
--- a/src/entities/profile/ui/profileHeader/ProfileHeader.module.scss
+++ b/src/entities/profile/ui/profileHeader/ProfileHeader.module.scss
@@ -15,6 +15,7 @@
   border-right: 1px solid #d8d8d8;
   overflow: hidden;
   transition: all 0.3s ease;
+  pointer-events: none;
 
   &__inner {
     display: flex;


### PR DESCRIPTION
## 변경사항
- 프로필 헤더 사이즈가 커서 헤더 영역에서 스크롤 시작 시 페이지 스크롤이 안되는 문제 해결

> [!NOTE]  
> 프로필 헤더에 별도의 이벤트가 필요 시 다른 솔루션이 필요합니다.