### PR TITLE
feat: ReactQuery 도입, useQuery 구현, ReviewList에서 적용, ReviewFilter 동작 설정

### DIFF
--- a/src/app/providers/index.tsx
+++ b/src/app/providers/index.tsx
@@ -1,9 +1,23 @@
 import { FC } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 interface IProviders {
     readonly children: JSX.Element
 }
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+      retry: 1,
+    },
+  },
+})
+
 export const Providers: FC<IProviders> = ({ children }) => {
-    return children
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  )
 }

--- a/src/entities/review/ui/reviewFilter/ReviewFilter.tsx
+++ b/src/entities/review/ui/reviewFilter/ReviewFilter.tsx
@@ -3,13 +3,18 @@ import styles from "./ReviewFilter.module.scss";
 import Button from "@/shared/ui/button/ui/Button";
 import filter from "@shared/assets/images/filter.svg";
 
-const ReviewFilter = () => {
-  const [activeFilter, setActiveFilter] = useState<"latest" | "highRating">(
-    "latest"
-  );
+interface ReviewFilterProps {
+  onSortChange: (filter: "latest" | "highRating") => void;
+}
+
+const ReviewFilter = ({ onSortChange }: ReviewFilterProps) => {
+  const [activeFilter, setActiveFilter] = useState<"latest" | "highRating">("latest");
+  
   const handleFilterClick = (filterType: "latest" | "highRating") => {
     setActiveFilter(filterType);
+    onSortChange(filterType);
   };
+
   return (
     <div className={styles.reviewFilter}>
       <div className={styles.reviewFilter__btnWraper}>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,12 +1,18 @@
 import { useState } from "react";
 import { ReviewList } from "@/widgets/reviewList";
 import ReviewFilter from "@/entities/review/ui/reviewFilter/ReviewFilter";
+import { useQueryClient } from '@tanstack/react-query';
 
 const Main = () => {
   const [sortType, setSortType] = useState<"NEW" | "HIGH_RATING">("NEW");
+  const queryClient = useQueryClient();
 
   const handleSortChange = (filter: "latest" | "highRating") => {
     setSortType(filter === "latest" ? "NEW" : "HIGH_RATING");
+    // 필터 변경 시 쿼리 무효화
+    queryClient.invalidateQueries({ 
+      queryKey: ['reviews', 'list', { sort: filter === "latest" ? "NEW" : "HIGH_RATING" }] 
+    });
   };
 
   return (

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,11 +1,18 @@
+import { useState } from "react";
 import { ReviewList } from "@/widgets/reviewList";
 import ReviewFilter from "@/entities/review/ui/reviewFilter/ReviewFilter";
 
 const Main = () => {
+  const [sortType, setSortType] = useState<"NEW" | "HIGH_RATING">("NEW");
+
+  const handleSortChange = (filter: "latest" | "highRating") => {
+    setSortType(filter === "latest" ? "NEW" : "HIGH_RATING");
+  };
+
   return (
     <div>
-      <ReviewFilter />
-      <ReviewList type="all" params={{ sort: "NEW", limit: 10 }} />
+      <ReviewFilter onSortChange={handleSortChange} />
+      <ReviewList type="all" params={{ sort: sortType, limit: 10 }} />
     </div>
   );
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -12,7 +12,14 @@ const Main = () => {
   return (
     <div>
       <ReviewFilter onSortChange={handleSortChange} />
-      <ReviewList type="all" params={{ sort: sortType, limit: 10 }} />
+      <ReviewList 
+        type="all" 
+        params={{ 
+          sort: sortType, 
+          limit: 10 
+        }}
+        key={sortType}
+      />
     </div>
   );
 };

--- a/src/shared/api/hooks/useQuery.ts
+++ b/src/shared/api/hooks/useQuery.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey } from '@tanstack/react-query'
+import { apiInstance } from '@shared/api/base'
+import type { AxiosError } from 'axios'
+
+export type ApiError = {
+  message: string
+  status?: number
+  data?: any
+}
+
+export const useApiQuery = <TData>(
+  queryKey: QueryKey,
+  endpoint: string,
+  options?: UseQueryOptions<TData, ApiError>
+) => {
+  return useQuery<TData, ApiError>({
+    queryKey,
+    queryFn: async () => {
+      const response = await apiInstance.get<TData>(endpoint)
+      return response
+    },
+    ...options,
+  })
+}
+
+export const useApiMutation = <TData, TVariables>(
+  endpoint: string,
+  method: 'post' | 'put' | 'patch' | 'delete',
+  options?: UseMutationOptions<TData, AxiosError, TVariables>
+) => {
+  return useMutation<TData, AxiosError, TVariables>({
+    mutationFn: async (variables) => {
+      const response = await apiInstance[method]<TData>(endpoint, variables)
+      return response
+    },
+    ...options,
+  })
+}

--- a/src/shared/api/reviews/reviewApi.ts
+++ b/src/shared/api/reviews/reviewApi.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useApiQuery, useApiMutation } from "@shared/api/hooks/useQuery";
+import { useQueryClient } from '@tanstack/react-query';
 import type {
   ReviewRequest,
   ReviewResponse,
@@ -10,6 +11,8 @@ import type {
 } from "./types";
 
 export const useReviewApi = () => {
+  const queryClient = useQueryClient();
+
   const createReviewMutation = useApiMutation<ReviewResponse, ReviewRequest>(
     "/api/reviews",
     "post"
@@ -24,6 +27,8 @@ export const useReviewApi = () => {
   ) => {
     try {
       const response = await createReviewMutation.mutateAsync(request);
+      // 리뷰 작성 성공 시 reviews 관련 쿼리 무효화
+      await queryClient.invalidateQueries({ queryKey: ['reviews'] });
       options?.onSuccess?.(response);
       return response;
     } catch (error) {

--- a/src/shared/api/reviews/reviewApi.ts
+++ b/src/shared/api/reviews/reviewApi.ts
@@ -1,5 +1,5 @@
-import { useApi } from "@shared/api/hooks/useApi";
 import { useCallback } from "react";
+import { useApiQuery, useApiMutation } from "@shared/api/hooks/useQuery";
 import type {
   ReviewRequest,
   ReviewResponse,
@@ -10,7 +10,10 @@ import type {
 } from "./types";
 
 export const useReviewApi = () => {
-  const { post, get, isLoading, error } = useApi<ReviewResponse>();
+  const createReviewMutation = useApiMutation<ReviewResponse, ReviewRequest>(
+    "/api/reviews",
+    "post"
+  );
 
   const createReview = async (
     request: ReviewRequest,
@@ -20,23 +23,41 @@ export const useReviewApi = () => {
     }
   ) => {
     try {
-      const response = await post(
-        "/api/reviews",
-        request,
-        {},
-        {
-          onSuccess: options?.onSuccess,
-          onError: options?.onError,
-        }
-      );
+      const response = await createReviewMutation.mutateAsync(request);
+      options?.onSuccess?.(response);
       return response;
     } catch (error) {
       console.error("리뷰 작성 중 오류 발생:", error);
+      options?.onError?.(error);
       throw error;
     }
   };
 
-  const getCafeReviews = async (
+  const useCafeReviews = (cafeId: number, params: ShowCafeReviewRequest) => {
+    return useApiQuery<ShowReviewResponse[]>(
+      ["reviews", "cafe", cafeId, params],
+      `/api/reviews/cafe/${cafeId}?${new URLSearchParams(params as any).toString()}`
+    );
+  };
+
+  const useReviewList = (params: ShowReviewListRequest = { sort: "NEW", limit: 10 }) => {
+    return useApiQuery<ShowReviewResponse[]>(
+      ["reviews", "list", params],
+      `/api/reviews/list?${new URLSearchParams(params as any).toString()}`
+    );
+  };
+
+  const useMyReviews = (params: ShowUserReviewRequest = { limit: 10 }) => {
+    return useApiQuery<ShowReviewResponse[]>(
+      ["reviews", "my", params],
+      `/api/reviews/my?${new URLSearchParams(params as any).toString()}`
+    );
+  };
+
+  /**
+   * 이하 레거시 호환을 위한 코드
+   */
+  const getCafeReviews = useCallback(async (
     cafeId: number,
     params: ShowCafeReviewRequest,
     options?: {
@@ -45,54 +66,56 @@ export const useReviewApi = () => {
     }
   ) => {
     try {
-      const response = await get<ShowReviewResponse[]>(
-        `/api/reviews/cafe/${cafeId}`,
-        { params },
-        {
-          onSuccess: options?.onSuccess,
-          onError: options?.onError,
-        }
-      );
-      return response;
+      const query = useCafeReviews(cafeId, params);
+      const response = await query.refetch();
+      options?.onSuccess?.(response.data || []);
+      return response.data || [];
     } catch (error) {
       console.error("카페 리뷰 조회 중 오류 발생:", error);
+      options?.onError?.(error);
       throw error;
     }
-  };
+  }, []);
 
   const getReviewList = useCallback(async (
-    params: ShowReviewListRequest = {
-      sort: "NEW",
-      limit: 10
-    }
+    params: ShowReviewListRequest = { sort: "NEW", limit: 10 }
   ) => {
     try {
-      return await get<ShowReviewResponse[]>('/api/reviews/list', { params });
+      const query = useReviewList(params);
+      const response = await query.refetch();
+      return response.data || [];
     } catch (error) {
       console.error("리뷰 목록 조회 중 오류 발생:", error);
       throw error;
     }
-  }, [get]);
+  }, []);
 
   const getMyReviews = useCallback(async (
-    params: ShowUserReviewRequest = {
-      limit: 10
-    }
+    params: ShowUserReviewRequest = { limit: 10 }
   ) => {
     try {
-      return await get<ShowReviewResponse[]>('/api/reviews/my', { params });
+      const query = useMyReviews(params);
+      const response = await query.refetch();
+      return response.data || [];
     } catch (error) {
       console.error("내 리뷰 목록 조회 중 오류 발생:", error);
       throw error;
     }
-  }, [get]);
+  }, []);
 
   return {
     createReview,
+    createReviewMutation,
+
+    useCafeReviews,
+    useReviewList,
+    useMyReviews,
+
     getCafeReviews,
     getReviewList,
     getMyReviews,
-    isLoading,
-    error,
+
+    isLoading: createReviewMutation.isPending,
+    error: createReviewMutation.error
   };
 };

--- a/src/widgets/reviewList/ui/ReviewList.tsx
+++ b/src/widgets/reviewList/ui/ReviewList.tsx
@@ -10,32 +10,30 @@ interface ReviewListProps {
 }
 
 const ReviewList = ({ type = 'all', params = { limit: 10 } }: ReviewListProps) => {
-  const [reviews, setReviews] = useState<ShowReviewResponse[]>([]);
-  const { getReviewList, getMyReviews } = useReviewApi();
+  const { useReviewList, useMyReviews } = useReviewApi();
+  
+  const reviewListQuery = useReviewList({
+    sort: "NEW",
+    ...params as ShowReviewListRequest
+  });
+  
+  const myReviewsQuery = useMyReviews({
+    ...params as ShowUserReviewRequest
+  });
 
-  useEffect(() => {
-    const fetchReviews = async () => {
-      try {
-        const response = type === 'all' 
-          ? await getReviewList({
-              sort: "NEW",
-              ...params as ShowReviewListRequest
-            })
-          : await getMyReviews({
-              ...params as ShowUserReviewRequest
-            });
-        setReviews(response);
-      } catch (error) {
-        console.error("Failed to fetch reviews:", error);
-      }
-    };
+  const reviews = type === 'all' ? reviewListQuery.data : myReviewsQuery.data;
 
-    fetchReviews();
-  }, [type, params, getReviewList, getMyReviews]);
+  if (reviewListQuery.isError || myReviewsQuery.isError) {
+    return <div>리뷰를 불러오는데 실패했습니다.</div>;
+  }
+
+  if (reviewListQuery.isLoading || myReviewsQuery.isLoading) {
+    return <div>로딩 중...</div>;
+  }
 
   return (
     <ul className={styles.reviewList}>
-      {reviews.map(review => (
+      {reviews?.map(review => (
         <li key={review.reviewId} className={styles.reviewList__item}>
           <ReviewItem review={review} showChips={true} />
         </li>


### PR DESCRIPTION
## 변경사항
- React Query 설정
  - QueryClient 설정 추가 (5분 staleTime, 1회 retry)
  - QueryClientProvider로 앱 전체 래핑
- useApiQuery, useApiMutation 커스텀 훅 구현
- 기존 리뷰 API 호출 로직을 React Query 기반으로 리팩토링
- useReviewApi 훅 변경
  - createReview -> 리뷰 작성 시 쿼리 무효화(강제 갱신)
  - 리뷰 정렬 순서 변경 시 쿼리 무효화(강제 갱신)
  - useCafeReviews, useReviewList, useMyReviews 커스텀 훅 추가
  - 레거시 호환성 유지를 위한 기존 메서드 유지
- ReviewFilter 컴포넌트에 정렬 기능 추가
- Main 페이지에서 정렬 상태 설정