### PR TITLE
fix: 프로필 수정 관련 로직 개선

### DIFF
--- a/src/app/routers/appRouter.tsx
+++ b/src/app/routers/appRouter.tsx
@@ -30,36 +30,13 @@ import { useProfileStore } from "@shared/store/useProfileStore";
 import { useProfileImageApi } from "@shared/api/user/useProfileImagesApi";
 import { useUserStore } from "@shared/store/useUserStore";
 import { useUserApi } from "@shared/api/user/userApi";
+import { useProfileEditStore } from "@shared/store/useProfileEditStore";
 
 export const AppRouter = () => {
   const { isFromFooter } = useNavigationStore();
   const draftCount = useDraftCountStore((state) => state.count);
-
-  const { file, setProfileImageUrl } = useProfileStore();
-  const { userData, nicknameError } = useUserStore();
-  const { uploadProfileImage, getProfileImage } = useProfileImageApi();
-  const { updateUserInfo } = useUserApi();
-
-  const handleCompleteClick = async () => {
-    try {
-      if (file) {
-        await uploadProfileImage(file);
-      }
-
-      const { nickname, introduce, userId } = userData;
-      await updateUserInfo({ nickname, introduce });
-      if (userId) {
-        const newImageUrl = await getProfileImage(userId);
-        if (newImageUrl) {
-          setProfileImageUrl(newImageUrl);
-        }
-      }
-      alert("프로필 수정이 완료되었습니다!");
-      window.location.href = "/mypage";
-    } catch (error) {
-      alert("수정 중 오류가 발생했습니다.");
-    }
-  };
+  const { nicknameError } = useUserStore();
+  const { handleComplete } = useProfileEditStore();
 
   const routes = createRoutesFromElements(
     <Route path="/" element={<Outlet />}>
@@ -180,7 +157,7 @@ export const AppRouter = () => {
               rightElement={
                 <button
                   className={`${styles.completeButton} ${styles["completeButton--color"]}`}
-                  onClick={handleCompleteClick}
+                  onClick={handleComplete}
                   disabled={!!nicknameError}
                 >
                   완료

--- a/src/entities/profile/ui/profileHeader/ProfileHeader.tsx
+++ b/src/entities/profile/ui/profileHeader/ProfileHeader.tsx
@@ -13,14 +13,12 @@ const ProfileHeader = ({ isScrolled }: ProfileHeaderProps) => {
   const [userInfo, setUserInfo] = useState<UserInfoResponse | null>(null);
   const { profileImageUrl, setProfileImageUrl } = useProfileStore();
 
-  // 별도의 useEffect로 분리
   useEffect(() => {
     const fetchUserData = async () => {
       try {
         const response = await getUserInfo();
         setUserInfo(response);
 
-        // 프로필 이미지 로딩
         if (response.userId) {
           const newImageUrl = await getProfileImage(response.userId);
           if (newImageUrl) {
@@ -32,9 +30,8 @@ const ProfileHeader = ({ isScrolled }: ProfileHeaderProps) => {
       }
     };
 
-    // 컴포넌트 마운트 시 한 번만 실행
     fetchUserData();
-  }, []); // 빈 의존성 배열
+  }, []);
 
   return (
     <div

--- a/src/entities/profile/ui/profileHeader/ProfileHeader.tsx
+++ b/src/entities/profile/ui/profileHeader/ProfileHeader.tsx
@@ -11,16 +11,16 @@ const ProfileHeader = ({ isScrolled }: ProfileHeaderProps) => {
   const { getUserInfo } = useUserApi();
   const { getProfileImage } = useProfileImageApi();
   const [userInfo, setUserInfo] = useState<UserInfoResponse | null>(null);
-
   const { profileImageUrl, setProfileImageUrl } = useProfileStore();
 
+  // 별도의 useEffect로 분리
   useEffect(() => {
     const fetchUserData = async () => {
       try {
         const response = await getUserInfo();
         setUserInfo(response);
 
-        // 여기서 userId를 이용해 프로필 이미지를 가져옴
+        // 프로필 이미지 로딩
         if (response.userId) {
           const newImageUrl = await getProfileImage(response.userId);
           if (newImageUrl) {
@@ -32,10 +32,9 @@ const ProfileHeader = ({ isScrolled }: ProfileHeaderProps) => {
       }
     };
 
-    if (!profileImageUrl) {
-      fetchUserData();
-    }
-  }, [profileImageUrl]);
+    // 컴포넌트 마운트 시 한 번만 실행
+    fetchUserData();
+  }, []); // 빈 의존성 배열
 
   return (
     <div

--- a/src/pages/MyPageEdit.tsx
+++ b/src/pages/MyPageEdit.tsx
@@ -1,19 +1,24 @@
 import { debounce } from "lodash";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useUserApi } from "@/shared/api/user/userApi";
 import { useProfileImageApi } from "@/shared/api/user/useProfileImagesApi";
 import { useUserStore } from "@/shared/store/useUserStore";
 import { useProfileStore } from "@/shared/store/useProfileStore";
+import { useProfileEditStore } from "@/shared/store/useProfileEditStore";
+import { useNavigate } from "react-router-dom";
 import PhotoEdit from "@/entities/profile/ui/photoEdit/PhotoEdit";
 import ProfileBtnWrap from "@/entities/profile/ui/profileBtnWrap/ProfileBtnWrap";
 import ProfileForm from "@/entities/profile/ui/profileForm/ProfileForm";
 import styles from "./styles/MyPageEdit.module.scss";
 
 const MyPageEdit = () => {
-  const { getUserInfo, checkNicknameExistence } = useUserApi();
-  const { setUserData, setNicknameError } = useUserStore();
-  const { getProfileImage } = useProfileImageApi();
-  const { setProfileImageUrl } = useProfileStore();
+  const { getUserInfo, checkNicknameExistence, updateUserInfo } = useUserApi();
+  const { setUserData, setNicknameError, userData } = useUserStore();
+  const { getProfileImage, uploadProfileImage } = useProfileImageApi();
+  const { setProfileImageUrl, file } = useProfileStore();
+  const { setHandleComplete } = useProfileEditStore();
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
 
   useEffect(() => {
     const fetchUserInfo = async () => {
@@ -40,6 +45,35 @@ const MyPageEdit = () => {
 
     fetchUserInfo();
   }, [setUserData, getProfileImage, setProfileImageUrl]);
+
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
+
+  useEffect(() => {
+    setHandleComplete(async () => {
+      try {
+        if (file) {
+          await uploadProfileImage(file);
+        }
+
+        const { nickname, introduce, userId } = userData;
+        await updateUserInfo({ nickname, introduce });
+        
+        if (userId) {
+          const newImageUrl = await getProfileImage(userId);
+          if (newImageUrl) {
+            setProfileImageUrl(newImageUrl);
+          }
+        }
+        
+        alert("프로필 수정이 완료되었습니다!");
+        navigateRef.current("/mypage", { replace: true });
+      } catch (error) {
+        alert("수정 중 오류가 발생했습니다.");
+      }
+    });
+  }, [file, userData, setHandleComplete]);
 
   const handleNicknameChange = debounce(async (nickname: string) => {
     if (nickname.length === 0) {

--- a/src/shared/store/useProfileEditStore.ts
+++ b/src/shared/store/useProfileEditStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface ProfileEditStore {
+  isEditing: boolean;
+  handleComplete: () => Promise<void>;
+  setHandleComplete: (handler: () => Promise<void>) => void;
+}
+
+export const useProfileEditStore = create<ProfileEditStore>((set) => ({
+  isEditing: false,
+  handleComplete: async () => {},
+  setHandleComplete: (handler) => set({ handleComplete: handler }),
+}));


### PR DESCRIPTION
## 변경사항 
- ProfileHeader에서 항상 사용자 정보를 fetching 하도록 변경
- 프로필 수정 로직을 `AppRouter`에서 `MyPageEdit` 컴포넌트로 이동
- 프로필 수정 상태 관리를 위한 `useProfileEditStore` 추가

## 주요 개선사항
1. `AppRouter`의 책임 분리
   - 라우팅 관련 로직과 프로필 수정 로직을 분리
   - 프로필 수정 핸들러를 store를 통해 관리하도록 변경

2. `MyPageEdit` 컴포넌트 개선
   - 프로필 수정 로직을 `MyPageEdit`로 이동
   - `useRef`를 사용하여 이전 navigate를 참조하는 문제 해결

3. `ProfileHeader` 컴포넌트 개선
   - 컴포넌트 마운트 시 항상 최신 데이터를 fetching하도록 변경