### PR TITLE
useBlocker 상세 동작 원리 및 페이지 이탈 방지 로직 개선

### DIFF
--- a/src/features/search/ui/SearchBar.tsx
+++ b/src/features/search/ui/SearchBar.tsx
@@ -4,8 +4,8 @@ import searchIcon from '@shared/assets/images/search/search.svg';
 import clearIcon from '@shared/assets/images/search/search-clear.svg';
 import styles from './SearchBar.module.scss';
 
-export const SearchBar = () => {
-  const [value, setValue] = useState('');
+export const SearchBar = ({ initialValue = '' }: { initialValue?: string }) => {
+  const [value, setValue] = useState(initialValue);
   const navigate = useNavigate();
 
   const handleSubmit = (e: FormEvent) => {

--- a/src/pages/CafeSearch.tsx
+++ b/src/pages/CafeSearch.tsx
@@ -145,6 +145,7 @@ const CafeSearch = () => {
         state: {
           from: "/search",
           searchParams: window.location.search,
+          isContinue: true,
         },
       });
     } else {
@@ -189,7 +190,7 @@ const CafeSearch = () => {
   return (
     <div className={styles.searchPage}>
       <div className={styles.searchBarWrapper}>
-        <SearchBar />
+        <SearchBar initialValue={searchParams.get('name') || ''} />
       </div>
       <div className={styles.cafeListContainer}>
         {isLoading ? (

--- a/src/pages/DraftReview.tsx
+++ b/src/pages/DraftReview.tsx
@@ -57,7 +57,12 @@ const DraftReview = () => {
 
       // 스토어 업데이트가 완료된 후 네비게이션
       Promise.resolve().then(() => {
-        navigate("/review/write", { state: { from: '/draft' } });
+        navigate("/review/write", { 
+          state: { 
+            from: '/draft',
+            isContinue: true
+          } 
+        });
       });
     }
 

--- a/src/shared/hooks/useBlocker.ts
+++ b/src/shared/hooks/useBlocker.ts
@@ -7,6 +7,12 @@ export const useBlocker = (blocker: () => void, enabled = true) => {
   const location = useLocation();
 
   useEffect(() => {
+    return () => {
+      hasPushedState.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
     if (!enabled) return;
 
     const currentPathname = location.pathname;

--- a/src/shared/hooks/useBlocker.ts
+++ b/src/shared/hooks/useBlocker.ts
@@ -12,10 +12,8 @@ export const useBlocker = (blocker: () => void, enabled = true) => {
     const currentPathname = location.pathname;
 
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      if (!isModalOpen.current) {
         event.preventDefault();
         event.returnValue = "";
-      }
     };
 
     const handlePopState = (event: PopStateEvent) => {


### PR DESCRIPTION
## 변경사항
### 기능 설명
useBlocker는 페이지 이탈 시 사용자에게 확인을 요청하는 커스텀 훅입니다. 주로 작성 중인 내용이 있을 때 실수로 페이지를 벗어나는 것을 방지하는데 사용됩니다.

### 구현 상세
#### 1. beforeunload 이벤트 처리
```typescript
const handleBeforeUnload = (event: BeforeUnloadEvent) => {
  if (!isModalOpen.current) {
    event.preventDefault();
    event.returnValue = "";
  }
};
```
- `beforeunload` 이벤트는 다음과 같은 상황에서 발생합니다:
  - 브라우저 탭/창 닫기
  - 브라우저 새로고침
  - URL 직접 변경
- `event.preventDefault()`로 기본 동작을 막고, `event.returnValue = ""`로 브라우저의 기본 경고 메시지를 표시합니다.

#### 2. popstate 이벤트 처리
```typescript
const handlePopState = (event: PopStateEvent) => {
  if (!isModalOpen.current) {
    event.preventDefault();
    window.history.pushState(null, "", currentPathname);
    blocker();
  }
};
```
- `popstate` 이벤트는 브라우저의 히스토리 스택이 변경될 때 발생합니다:
  - 뒤로가기 버튼 클릭
  - 앞으로가기 버튼 클릭
  - history.back() 호출
- 이벤트 발생 시 현재 URL을 히스토리에 다시 추가하여 페이지 이동을 방지합니다.
- `blocker` 콜백을 실행하여 사용자에게 확인 모달을 표시합니다.

#### 3. window.history.pushState 활용
```typescript
if (!hasPushedState.current) {
  window.history.pushState(null, "", currentPathname);
  hasPushedState.current = true;
}
```
- `window.history.pushState`는 브라우저의 히스토리 스택을 조작하는 메서드입니다.
- useBlocker에서는 히스토리 스택에 현재 페이지 URL을 의도적으로 중복 유지합니다:
```typescript
// 초기 진입 시
['/search', '/write-review']

// pushState 실행 후
['/search', '/review/write', '/review/write']
```
이렇게 같은 URL을 연속으로 스택에 넣어둠으로써,

뒤로가기를 눌러도 실제로는 같은 `/review/write` 페이지를 바라보게 만들고 그 사이에 popstate 이벤트를 감지해서 모달을 띄웁니다.

이렇게 하면:

컴포넌트가 언마운트되지 않음
상태가 유지됨
모달을 안전하게 띄울 수 있음

hasPushedState ref로 중복 푸시 방지:
```typescript
const hasPushedState = useRef(false);
```

### 테스트 방법
1. 페이지 새로고침 시도
```typescript
// 브라우저 새로고침
window.location.reload();
// 브라우저 기본 경고 메시지 표시 확인
```

2. 뒤로가기 버튼 클릭
```typescript
// 뒤로가기 클릭
history.back();
// URL 변경 없음 확인
// 확인 모달 표시 확인
```

### 추가 개선 사항
- `/review/write` 접속 방법에 따라 모달의 팝업 여부를 결정합니다.
  - 새로 작성하는 리뷰인 경우 모달을 팝업
  - 이어서 작성하는 리뷰인 경우 바로 뒤로가기

### To-Do
- [ ] 모달 표시 상태에서의 뒤로가기 처리 개선
  - 현재: 모달이 열려있어도 뒤로가기 시 페이지 이동 차단
  - 제안: 모달 상태에서 뒤로가기 시 모달 닫기 처리