### PR TITLE
fix: 카페의 인스타그램 계정명을 링크 텍스트로 사용

### DIFF
--- a/src/entities/cafeInfo/ui/CafeInfoItem.tsx
+++ b/src/entities/cafeInfo/ui/CafeInfoItem.tsx
@@ -31,7 +31,14 @@ const CafeInfoItem = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              Instagram
+              {(() => {
+                const isInstagram = instaLink.includes('instagram.com');
+                const username = instaLink.split('/').pop();
+                if (isInstagram && username) {
+                  return `@${username}`;
+                }
+                return 'welcome';
+              })()}
             </a>
           )}
         </div>


### PR DESCRIPTION
# 변경사항

## 기능 설명
- 카페의 인스타그램 계정명을 링크 텍스트로 사용합니다.
- 인스타그램 링크가 아닐 경우 'welcome'으로 표시합니다.

## 구현 상세
### 변경 전
![image](https://github.com/user-attachments/assets/bb9e3821-02cf-4ec8-bdd7-f0c28ce76752)
### 변경 후
![image](https://github.com/user-attachments/assets/ac1f34f3-6f9c-4364-aedf-7ba740e0d1a4)