### PR TITLE
feat: 메인페이지 팔로잉 탭 추가, 기능 구현

### DIFF
--- a/src/entities/review/ui/reviewFilter/ReviewFilter.module.scss
+++ b/src/entities/review/ui/reviewFilter/ReviewFilter.module.scss
@@ -2,7 +2,7 @@
 @use "/src/app/styles/abstracts/variables" as var;
 
 .reviewFilter {
-  padding: 8px 16px 0;
+  padding: 16px 16px 0;
 
   display: flex;
   justify-content: space-between;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { ReviewList } from "@/widgets/reviewList";
 import ReviewFilter from "@/entities/review/ui/reviewFilter/ReviewFilter";
 import { useQueryClient } from "@tanstack/react-query";
+import { Tabs } from "@shared/ui/tabs/Tabs";
+import type { Tab } from "@shared/ui/tabs/types";
 
 const Main = () => {
   const [sortType, setSortType] = useState<"NEW" | "HIGH_RATING">("NEW");
@@ -10,7 +12,13 @@ const Main = () => {
     new Date(3000, 0, 1).toISOString()
   );
   const [lastRating, setLastRating] = useState<number | undefined>();
+  const [activeTab, setActiveTab] = useState<string>("explore");
   const queryClient = useQueryClient();
+
+  const tabs: Tab[] = [
+    { id: "explore", label: "탐색" },
+    { id: "following", label: "팔로잉" },
+  ];
 
   const handleSortChange = (filter: "latest" | "highRating") => {
     setSortType(filter === "latest" ? "NEW" : "HIGH_RATING");
@@ -42,12 +50,17 @@ const Main = () => {
 
   return (
     <div>
-      <ReviewFilter
-        onSortChange={handleSortChange}
-        onTagsConfirm={handleTagsConfirm}
-      />
+      <div>
+        <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
+      </div>
+      {activeTab === "explore" && (
+        <ReviewFilter
+          onSortChange={handleSortChange}
+          onTagsConfirm={handleTagsConfirm}
+        />
+      )}
       <ReviewList
-        type="all"
+        type={activeTab === "explore" ? "all" : "follow"}
         params={{
           sort: sortType,
           limit: 10,
@@ -58,7 +71,7 @@ const Main = () => {
           }),
         }}
         onLoadMore={handleLoadMore}
-        key={`${sortType}-${selectedTagIds.join(",")}`}
+        key={`${activeTab}-${sortType}-${selectedTagIds.join(",")}`}
       />
     </div>
   );

--- a/src/shared/api/reviews/reviewApi.ts
+++ b/src/shared/api/reviews/reviewApi.ts
@@ -150,6 +150,28 @@ export const useReviewApi = () => {
     );
   };
 
+  const useFollowingReviews = (params: ShowUserReviewRequest = { limit: 10 }) => {
+    const validatedParams = {
+      limit: Math.min(Math.max(params.limit || 10, 1), 20),
+      ...(params.timestamp
+        ? {
+            timestamp: params.timestamp?.endsWith("Z")
+              ? params.timestamp.slice(0, -1)
+              : params.timestamp,
+          }
+        : {}),
+    };
+
+    const cleanParams = Object.fromEntries(
+      Object.entries(validatedParams).filter(([_, value]) => value != null)
+    );
+
+    return useApiQuery<ShowReviewResponse[]>(
+      ["reviews", "following", validatedParams],
+      `/api/reviews/follow?${new URLSearchParams(cleanParams as any).toString()}`
+    );
+  };
+
   /**
    * 이하 레거시 호환을 위한 코드
    */
@@ -226,6 +248,7 @@ export const useReviewApi = () => {
     useReviewList,
     useUserReviews,
     useMyReviews,
+    useFollowingReviews,
 
     getCafeReviews,
     getReviewList,


### PR DESCRIPTION
# 변경사항
## 기능 설명
- 메인 페이지에 '팔로잉' 탭을 추가하여 사용자가 팔로우한 사용자들의 리뷰만 볼 수 있는 기능 구현

## 구현 상세
### 1. 메인 페이지 탭 UI 구현
- `Tabs` 컴포넌트를 활용하여 '탐색'과 '팔로잉' 탭 구현
- 선택된 탭에 따라 다른 리뷰 목록 및 필터링 옵션 표시
- 기본 탭은 '탐색'으로 설정

### 2. 팔로잉 API 연동
- 팔로우한 사용자들의 리뷰를 가져오는 `useFollowingReviews` API 훅 구현
- `ReviewList` 컴포넌트에 'follow' 타입 추가하여 팔로잉 리뷰 표시 지원
- 팔로잉 탭 선택 시 필터 컴포넌트 숨김 처리

### 3. 리뷰 목록 컴포넌트 개선
- `ReviewList` 컴포넌트의 타입에 'follow' 추가
- 로딩 상태 관리 로직에 팔로잉 리뷰 쿼리 상태 추가
- 리뷰 목록 key 값에 activeTab 정보 추가하여 탭 전환 시 리스트 갱신

## 테스트 방법
1. 메인 페이지 접속
2. '팔로잉' 탭 클릭
3. 팔로우한 사용자들의 리뷰만 표시되는지 확인
4. '탐색' 탭으로 돌아가서 필터 컴포넌트가 정상적으로 표시되는지 확인
5. 탭 전환 시 리뷰 목록이 적절히 갱신되는지 확인

## 체크리스트
- [ ] 테스트 코드를 작성하였습니까?
- [x] 타입 안정성을 검증하였습니까?
- [x] 코드 컨벤션을 준수하였습니까?
- [ ] 관련 문서를 업데이트하였습니까?
- [x] 사용자 경험을 고려하였습니까?

## 추가 설명
### Known Issues
- 팔로잉 리뷰가 없을 경우 빈 화면 처리 개선 필요

### To-Do
- [ ] 팔로잉 없는 경우 안내 메시지 추가
- [ ] 팔로잉 추천 기능 구현 검토

### 기타 고려사항
- 팔로잉 탭에서는 필터링 옵션을 숨기는 방식으로 구현했으나, 향후 팔로잉 리뷰에 대한 별도 필터링 기능 추가 검토 필요
- 페이지네이션 로직은 기존 코드를 재활용하여 구현했으므로 동작에 문제가 없음