### PR TITLE
fix: 탭 전환 시 timestamp 초기화, 로딩 메세지

### DIFF
--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -42,6 +42,13 @@ const Main = () => {
     }
   };
 
+  const handleTabChange = (newTab: string) => {
+    setActiveTab(newTab);
+    setLastTimestamp(new Date(3000, 0, 1).toISOString());
+    setLastRating(undefined);
+    invalidateReviewsQuery();
+  };
+
   const invalidateReviewsQuery = () => {
     queryClient.invalidateQueries({
       queryKey: ["reviews", "list"],
@@ -51,7 +58,11 @@ const Main = () => {
   return (
     <div>
       <div>
-        <Tabs tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
+        <Tabs 
+          tabs={tabs} 
+          activeTab={activeTab} 
+          onTabChange={handleTabChange} 
+        />
       </div>
       {activeTab === "explore" && (
         <ReviewFilter

--- a/src/widgets/reviewList/ui/ReviewList.tsx
+++ b/src/widgets/reviewList/ui/ReviewList.tsx
@@ -130,13 +130,18 @@ const ReviewList = ({ type = 'all', params = { limit: 10 }, onLoadMore }: Review
 
   return (
     <div>
-      {reviews.length === 0 ? 
-      <NoContent 
-        logo="noReview"
-        mainContent="아직 작성된 리뷰가 없어요"
-        subContent="최근에 다녀오신 카페는 어땠나요?"
-      />
-      : <div className={styles.reviewListContainer}>
+      {isLoading && reviews.length === 0 ? (
+        <div className={styles.loadingIndicator}>
+          로딩 중...
+        </div>
+      ) : reviews.length === 0 ? (
+        <NoContent 
+          logo="noReview"
+          mainContent="아직 작성된 리뷰가 없어요"
+          subContent="최근에 다녀오신 카페는 어땠나요?"
+        />
+      ) : (
+        <div className={styles.reviewListContainer}>
           <ul className={styles.reviewList}>
             {reviews.map(review => (
               <li key={review.reviewId} className={styles.reviewList__item}>
@@ -144,16 +149,16 @@ const ReviewList = ({ type = 'all', params = { limit: 10 }, onLoadMore }: Review
                   review={review} 
                   showChips={true}
                   currentUserId={currentUserId} 
-                  />
+                />
               </li>
             ))}
           </ul>
 
           {hasMore && (
             <div 
-            ref={loadMoreTriggerRef}
-            className={styles.loadMoreTrigger}
-            style={{ height: '20px', margin: '20px 0' }}
+              ref={loadMoreTriggerRef}
+              className={styles.loadMoreTrigger}
+              style={{ height: '20px', margin: '20px 0' }}
             />
           )}
           
@@ -163,7 +168,7 @@ const ReviewList = ({ type = 'all', params = { limit: 10 }, onLoadMore }: Review
             </div>
           )}
         </div>
-      }
+      )}
     </div>
   );
 };


### PR DESCRIPTION
# 변경사항
## 기능 설명
- 데이터 로딩 상태 표시 개선
- 탭 전환 시 데이터 초기화 로직 수정

## 구현 상세
### 1. 리뷰 목록 초기 로딩 상태 처리 개선
- 로딩 중에는 로딩 메세지만 표시하도록 변경
- 데이터 로딩 완료 후 실제로 데이터가 없는 경우에만 NoContent 컴포넌트 표시

### 2. 탭 전환 시 데이터 관리 개선
- 탭 전환 시 timestamp를 초기값으로 리셋하여 새 탭 데이터를 처음부터 불러오도록 수정
- 탭 변경 시 lastRating 상태도 함께 초기화
- 탭 전환 후 쿼리 무효화하여 새로운 데이터 요청

## 테스트 방법
1. 리뷰 목록(메인페이지) 화면에 접속
2. 데이터 로딩 중일 때 로딩 메세지가 제대로 표시되는지 확인(개발자도구에서 네트워크 느리게 설정)
3. 다른 탭으로 전환 시 새로운 탭의 데이터가 처음부터 정상적으로 로드되는지 확인
