### PR TITLE
fix: showFooter=false 기본 padding 제거, 로그인 btnWrap 스타일 이전, 리뷰작성 페이지 여백 설정

### DIFF
--- a/src/app/layout/mainLayout/MainLayout.module.scss
+++ b/src/app/layout/mainLayout/MainLayout.module.scss
@@ -14,6 +14,10 @@
   position: relative;
   overflow: hidden;
   overscroll-behavior: none; // 전체 레이아웃의 오버스크롤 방지
+
+  &--noFooter {
+    padding-bottom: 0;
+  }
 }
 
 .mainContent {

--- a/src/app/layout/mainLayout/MainLayout.tsx
+++ b/src/app/layout/mainLayout/MainLayout.tsx
@@ -64,7 +64,7 @@ const MainLayout = ({
   };
 
   return (
-    <div className={styles.mainLayout}>
+    <div className={`${styles.mainLayout} ${!showFooter ? styles['mainLayout--noFooter'] : ''}`}>
       {showHeader && (
         <Header
           title={headerTitle}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -7,8 +7,7 @@ import googleLogo from "@shared/assets/images/social-icons/google-logo.svg";
 import facebookLogo from "@shared/assets/images/social-icons/facebook-logo.svg";
 import { useAuthStore } from "@app/auth/useAuthStore";
 import axios from "axios";
-import buttonStyles from "@/shared/ui/button/ui/Button.module.scss";
-import loginStyles from "./styles/Login.module.scss";
+import styles from "./styles/Login.module.scss";
 import { useEffect } from "react";
 
 axios.defaults.withCredentials = true;
@@ -33,27 +32,27 @@ const Login = () => {
   };
 
   return (
-    <div className={loginStyles.loginWrap}>
+    <div className={styles.loginWrap}>
       <LogoWrap>
         <Logo />
       </LogoWrap>
-      <div className={buttonStyles.btnWrap}>
+      <div className={styles.btnWrap}>
         <Button
-          className={`${buttonStyles.loginBtn} ${buttonStyles.naverBtn}`}
+          className={`${styles.loginBtn} ${styles.naverBtn}`}
           text="네이버로 시작하기"
           imgUrl={naverLogo}
           altText="네이버 로그인"
           onClick={() => handleLogin("naver")}
         />
         <Button
-          className={`${buttonStyles.loginBtn} ${buttonStyles.googleBtn}`}
+          className={`${styles.loginBtn} ${styles.googleBtn}`}
           text="구글로 시작하기"
           imgUrl={googleLogo}
           altText="구글 로그인"
           onClick={() => handleLogin("google")}
         />
         <Button
-          className={`${buttonStyles.loginBtn} ${buttonStyles.faceBtn}`}
+          className={`${styles.loginBtn} ${styles.faceBtn}`}
           text="페이스북으로 시작하기"
           imgUrl={facebookLogo}
           altText="페이스북 로그인"

--- a/src/pages/styles/Login.module.scss
+++ b/src/pages/styles/Login.module.scss
@@ -1,5 +1,41 @@
+@use "/src/app/styles/abstracts/mixins";
+@use "/src/app/styles/abstracts/variables" as var;
+
 .loginWrap {
   display: flex;
   flex-direction: column;
   height: 100%;
+}
+
+.btnWrap {
+  padding: 16px 16px 24px 16px;
+}
+
+.loginBtn {
+  margin-top: 16px;
+  padding: 16px;
+  width: 100%;
+  height: 56px;
+  gap: 16px;
+
+  @include mixins.apply-text-style(b1_bold);
+
+  border-radius: var.$radius-radius-lg;
+}
+
+.loginBtn.naverBtn {
+  margin-top: 0;
+  color: var.$semantic-text-icon-button-default;
+  background-color: #03c75a;
+}
+
+.loginBtn.googleBtn {
+  color: var.$semantic-text-icon-primary;
+  background-color: var.$semantic-background-primary;
+  border: 1px solid var.$semantic-border-primary;
+}
+
+.loginBtn.faceBtn {
+  color: var.$semantic-text-icon-button-default;
+  background-color: #1977f3;
 }

--- a/src/pages/styles/WriteReview.module.scss
+++ b/src/pages/styles/WriteReview.module.scss
@@ -2,13 +2,13 @@
 @use "@app/styles/abstracts/variables" as var;
 @use "@app/styles/abstracts/mixins";
 
-$bottom-nav-height: 34px;
-$button-height: 56px;
-$spacing: 32px;
+$bottom-nav-height: 34px; // 버튼 하단 여백
+$button-height: 56px; // 버튼 높이
+$spacing: 32px; // 버튼 상단 여백
 
 .container {
-  // padding-bottom: calc(#{$bottom-nav-height} + #{$button-height} + #{$spacing});
-  padding-bottom: calc(#{$button-height});
+  padding-bottom: calc(#{$bottom-nav-height} + #{$button-height} + #{$spacing});
+  // padding-bottom: calc(#{$button-height});
   position: relative;
   z-index: 1;
 

--- a/src/shared/ui/button/ui/Button.module.scss
+++ b/src/shared/ui/button/ui/Button.module.scss
@@ -1,34 +1,3 @@
-@use "/src/app/styles/abstracts/mixins";
-@use "/src/app/styles/abstracts/variables" as var;
-
 .btnWrap {
   padding: 16px;
-  .loginBtn {
-    margin-top: 16px;
-    padding: 16px;
-    width: 100%;
-    height: 56px;
-    gap: 16px;
-
-    @include mixins.apply-text-style(b1_bold);
-
-    border-radius: var.$radius-radius-lg;
-  }
-
-  .loginBtn.naverBtn {
-    margin-top: 0;
-    color: var.$semantic-text-icon-button-default;
-    background-color: #03c75a;
-  }
-
-  .loginBtn.googleBtn {
-    color: var.$semantic-text-icon-primary;
-    background-color: var.$semantic-background-primary;
-    border: 1px solid var.$semantic-border-primary;
-  }
-
-  .loginBtn.faceBtn {
-    color: var.$semantic-text-icon-button-default;
-    background-color: #1977f3;
-  }
 }


### PR DESCRIPTION
# 변경사항
## 기능 설명
- MainLayout에서 showFooter=false 일 때 패딩 제거 및 여백 개선
- 로그인 페이지 버튼 스타일 코드 이동 (Button.module.scss → Login.module.scss)
- 리뷰 작성 페이지 여백 설정 복원

## 구현 상세
### 1. MainLayout 여백 개선 (showFooter=false 일 때)
- MainLayout에 `mainLayout--noFooter` 클래스를 추가하여 footer가 없을 때 하단 여백 제거
- showFooter prop에 따라 조건부 클래스 적용

### 2. 로그인 버튼 스타일 코드 위치 이동
- 로그인 관련 스타일(.loginBtn, .naverBtn 등)을 Button.module.scss에서 Login.module.scss로 이동

### 3. 리뷰 작성 페이지 여백 설정
- 하단 여백 계산식 변경: `padding-bottom: calc(#{$bottom-nav-height} + #{$button-height} + #{$spacing})`