### PR TITLE
fix: 팔로잉/팔로워 페이지 랜더링시 useInfiniteQuery 함수 자동 호출 방지

### DIFF
--- a/src/pages/FollowListPage.tsx
+++ b/src/pages/FollowListPage.tsx
@@ -22,9 +22,9 @@ const FollowListPage = () => {
 		{ id: "follower", label: "팔로워" },
 		{ id: "following", label: "팔로잉" },
 	];  
-	const {useFollowerList, useFollowingList} = useFollowApi();
-	const {data: followerList, fetchNextPage: fetchFollowerNextPage, hasNextPage: hasFollowerNexPage, refetch: refetchFollowerList, isLoading: isFollowerLoading} = useFollowerList(Number(id), { limit : 20 });
-	const {data: followingList, fetchNextPage: fetchFollowingNextPage, hasNextPage: hasFollowingNexPage,refetch: refetchFollowingList, isLoading: isFollowingLoading} = useFollowingList(Number(id), { limit : 20 });
+	const {useLazyInfiniteFollowerList, useLazyInfiniteFollowingList} = useFollowApi();
+	const {data: followerList, fetchNextPage: fetchFollowerNextPage, hasNextPage: hasFollowerNexPage, refetch: refetchFollowerList, isLoading: isFollowerLoading} = useLazyInfiniteFollowerList(Number(id), { limit : 20 });
+	const {data: followingList, fetchNextPage: fetchFollowingNextPage, hasNextPage: hasFollowingNexPage,refetch: refetchFollowingList, isLoading: isFollowingLoading} = useLazyInfiniteFollowingList(Number(id), { limit : 20 });
 
 	useEffect(() => {
 		switch (activeTab) {

--- a/src/shared/api/follow/followApi.ts
+++ b/src/shared/api/follow/followApi.ts
@@ -7,6 +7,7 @@ import {
 	useInfiniteQuery,
   useQueryClient,
 } from "@tanstack/react-query";
+import { apiInstance } from "../base";
 
 export const useFollowApi = () => {
 	const queryClient = useQueryClient();
@@ -80,7 +81,7 @@ export const useFollowApi = () => {
 	// };
 
 	// 팔로워 리스트 조회 (cursor 기반 무한스크롤)
-	const useFollowerList = (userId: number, params: UserFollowRequest = {
+	const useInfiniteFollowerList = (userId: number, params: UserFollowRequest = {
 		limit : 10
 	}) => {
 		if (!userId) {
@@ -91,12 +92,12 @@ export const useFollowApi = () => {
 			`/api/users/${userId}/follower?limit=${params.limit}`,	//cursor 파라미터값은 useApiInfiniteQuery에서 자동설정됨
 			(lastPage: UserFollowResponse[]) => {
 				return (!lastPage || lastPage.length === 0) ? null : (lastPage.at(-1)?.followId ?? null);
-			}
+			},
 		);
 	};
 
 	// 팔로잉 리스트 조회 (cursor 기반 무한스크롤)
-	const useFollowingList = (userId: number, params: UserFollowRequest = {
+	const useInfiniteFollowingList = (userId: number, params: UserFollowRequest = {
 		limit : 10
 	}) => {
 		if (!userId) {
@@ -111,10 +112,62 @@ export const useFollowApi = () => {
 		);
 	};
 
+	// 팔로워 리스트 조회 (cursor 기반 무한스크롤) (초기 실행시 쿼리 자동 실행하지 않도록 설정)
+	const useLazyInfiniteFollowerList = (userId: number, params: UserFollowRequest = {
+		limit : 10
+	}) => {
+		if (!userId) {
+			console.log("useFollowerList 오류 : userId 존재x");
+		}
+
+		return useInfiniteQuery<UserFollowResponse[]>({
+			queryKey : ['follower', userId, params],
+			queryFn: async ({ pageParam = null}) => {
+				const url = `/api/users/${userId}/follower?limit=${params.limit}`;
+				return pageParam 
+					? await apiInstance.get<UserFollowResponse[]>(`${url}&cursor=${pageParam}`) 
+					: await apiInstance.get<UserFollowResponse[]>(`${url}`);
+			},
+			getNextPageParam : (lastPage: UserFollowResponse[]) => {
+				return (!lastPage || lastPage.length === 0) ? null : (lastPage.at(-1)?.followId ?? null);
+			},
+			throwOnError: true,
+			initialPageParam: null,
+			enabled: false, // 쿼리를 자동 실행하지 않도록 설정
+		});
+	}
+
+		// 팔로잉 리스트 조회 (cursor 기반 무한스크롤) (초기 실행시 쿼리 자동 실행하지 않도록 설정)
+		const useLazyInfiniteFollowingList = (userId: number, params: UserFollowRequest = {
+			limit : 10
+		}) => {
+			if (!userId) {
+				console.log("useFollowerList 오류 : userId 존재x");
+			}
+	
+			return useInfiniteQuery<UserFollowResponse[]>({
+				queryKey : ['following', userId, params],
+				queryFn: async ({ pageParam = null}) => {
+					const url = `/api/users/${userId}/following?limit=${params.limit}`;
+					return pageParam 
+						? await apiInstance.get<UserFollowResponse[]>(`${url}&cursor=${pageParam}`) 
+						: await apiInstance.get<UserFollowResponse[]>(`${url}`);
+				},
+				getNextPageParam : (lastPage: UserFollowResponse[]) => {
+					return (!lastPage || lastPage.length === 0) ? null : (lastPage.at(-1)?.followId ?? null);
+				},
+				throwOnError: true,
+				initialPageParam: null,
+				enabled: false, // 쿼리를 자동 실행하지 않도록 설정
+			});
+		}
+
 	return {
 		useFollow,
 		useUnfollow,
-		useFollowerList,
-		useFollowingList,
+		useInfiniteFollowerList,
+		useInfiniteFollowingList,
+		useLazyInfiniteFollowerList,
+		useLazyInfiniteFollowingList
 	};
 }

--- a/src/shared/api/hooks/useQuery.ts
+++ b/src/shared/api/hooks/useQuery.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey, useInfiniteQuery, UseInfiniteQueryOptions, InfiniteData } from '@tanstack/react-query'
+import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey, useInfiniteQuery } from '@tanstack/react-query'
 // import { useMutation, useSuspenseQuery, type UseMutationOptions, type UseSuspenseQueryOptions, type QueryKey } from '@tanstack/react-query'
 import { apiInstance } from '@shared/api/base'
 import type { AxiosError } from 'axios'
@@ -52,7 +52,6 @@ export const useApiInfiniteQuery = <TData>(
   queryKey: QueryKey,
   endpoint: string | (() => string),
   getNextPageParam: (lastPage: any, allPages: any) => number | null,
-  options?: any
 ) => {
   return useInfiniteQuery<TData>({
     queryKey,
@@ -66,6 +65,5 @@ export const useApiInfiniteQuery = <TData>(
     throwOnError: true,
     getNextPageParam,
     initialPageParam: null,
-    ...options,
   });
 };

--- a/src/shared/api/hooks/useQuery.ts
+++ b/src/shared/api/hooks/useQuery.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey, useInfiniteQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey, useInfiniteQuery, UseInfiniteQueryOptions, InfiniteData } from '@tanstack/react-query'
 // import { useMutation, useSuspenseQuery, type UseMutationOptions, type UseSuspenseQueryOptions, type QueryKey } from '@tanstack/react-query'
 import { apiInstance } from '@shared/api/base'
 import type { AxiosError } from 'axios'
@@ -51,7 +51,8 @@ export const useApiMutation = <TData, TVariables>(
 export const useApiInfiniteQuery = <TData>(
   queryKey: QueryKey,
   endpoint: string | (() => string),
-  getNextPageParam: (lastPage: any, allPages: any) => number | null
+  getNextPageParam: (lastPage: any, allPages: any) => number | null,
+  options?: any
 ) => {
   return useInfiniteQuery<TData>({
     queryKey,
@@ -65,5 +66,6 @@ export const useApiInfiniteQuery = <TData>(
     throwOnError: true,
     getNextPageParam,
     initialPageParam: null,
+    ...options,
   });
 };

--- a/src/shared/api/hooks/useQuery.ts
+++ b/src/shared/api/hooks/useQuery.ts
@@ -51,7 +51,7 @@ export const useApiMutation = <TData, TVariables>(
 export const useApiInfiniteQuery = <TData>(
   queryKey: QueryKey,
   endpoint: string | (() => string),
-  getNextPageParam: (lastPage: any, allPages: any) => number | null,
+  getNextPageParam: (lastPage: any, allPages: any) => number | null
 ) => {
   return useInfiniteQuery<TData>({
     queryKey,


### PR DESCRIPTION
# 변경사항

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
- useInfiniteQuery를 사용한 함수가 존재하는 컴포넌트 랜더링시 자동 호출되지 않도록 함

## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
### 1. useInfiniteQuery에 설정 추가
#### useApi.tsx에 추가된 함수
- useInfiniteQuery의 enabled: false 설정을 통해 마운트,랜더링될때 자동 api 호출되는것을 막습니다.
   ( 해당 api 요청함수는 enabled 설정을 위해 자체 커스텀 훅인 useApiInfiniteQuery를 사용하지 않았습니다. )
```typescript
// 팔로잉 리스트 조회 (cursor 기반 무한스크롤) (초기 실행시 쿼리 자동 실행하지 않도록 설정)
const useLazyInfiniteFollowingList = (userId: number, params: UserFollowRequest = {
limit : 10
}) => {
if (!userId) {
  console.log("useFollowerList 오류 : userId 존재x");
}

return useInfiniteQuery<UserFollowResponse[]>({
  queryKey : ['following', userId, params],
  queryFn: async ({ pageParam = null}) => {
    const url = `/api/users/${userId}/following?limit=${params.limit}`;
    return pageParam 
      ? await apiInstance.get<UserFollowResponse[]>(`${url}&cursor=${pageParam}`) 
      : await apiInstance.get<UserFollowResponse[]>(`${url}`);
  },
  getNextPageParam : (lastPage: UserFollowResponse[]) => {
    return (!lastPage || lastPage.length === 0) ? null : (lastPage.at(-1)?.followId ?? null);
  },
  throwOnError: true,
  initialPageParam: null,
  enabled: false, // 쿼리를 자동 실행하지 않도록 설정
});
}
``` 

#### 기존의 FollowListPage.tsx
- useInfiniteQuery의 refetch함수를 통해 탭 클릭시 api가 호출되도록 합니다
```typescript
useEffect(() => {
  switch (activeTab) {
    case "follower":
      refetchFollowerList();					// 무한 스크롤 리셋
      break;
    case "following":
      refetchFollowingList();					// 무한 스크롤 리셋
      break;
  }
}, [activeTab]);
``` 


## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. 팔로잉/팔로워 페이지 들어갈때 개발자도구의 네트워크 탭을 통해 팔로워 리스트 조회 api나 팔로우 리스트 조회 api 중 하나만 요청되는 것 확인
2. 팔로잉/팔로워 페이지 <-> 마이/유저 페이지 여러번 이동하면서 오류 발생하지 않는지 확인


