### PR TITLE
feat: 유저/마이 페이지 랜더링시 로딩 스피너 띄우기

### DIFF
--- a/src/app/routers/appRouter.tsx
+++ b/src/app/routers/appRouter.tsx
@@ -36,6 +36,8 @@ import TestError from "@/shared/components/TestError";
 import GeneralErrorPage from "@/shared/components/GeneralErrorPage";
 import UserPage from "@/pages/UserPage";
 import { useProfileEditStore } from "@shared/store/useProfileEditStore";
+import { Suspense } from "react";
+import Loading from "@/shared/ui/loading/Loading";
 
 export const AppRouter = () => {
   const { isFromFooter } = useNavigationStore();
@@ -157,7 +159,11 @@ export const AppRouter = () => {
               bgColor="rgb(249, 248, 246)"
               rightElement={<NavBtn />}
             >
-              <MyPage />
+              <Suspense fallback={
+                <Loading />
+              }>
+                <MyPage />
+              </Suspense>
             </MainLayout>
           }
           handle={{ crumb: <Link to="/mypage">마이페이지</Link> }}
@@ -195,7 +201,11 @@ export const AppRouter = () => {
               showBackButton={true}
               bgColor="rgb(249, 248, 246)"
             >
-              <UserPage />
+              <Suspense fallback={
+                <Loading />
+              }>
+                <UserPage />
+              </Suspense>
             </MainLayout>
           }
           handle={{ crumb: <Link to="/user">유저페이지</Link> }}

--- a/src/pages/CafeInfo.tsx
+++ b/src/pages/CafeInfo.tsx
@@ -131,7 +131,7 @@ const CafeInfo = () => {
         state: { from: `/cafe/${cafeInfo?.id}` }
       });
       setShouldNavigate(false);
-    } 
+    }
   }, [shouldNavigate, navigate, cafeInfo]);
 
   if (isLoading || reviewsQuery.isLoading) {

--- a/src/pages/CafeInfo.tsx
+++ b/src/pages/CafeInfo.tsx
@@ -131,7 +131,7 @@ const CafeInfo = () => {
         state: { from: `/cafe/${cafeInfo?.id}` }
       });
       setShouldNavigate(false);
-    }
+    } 
   }, [shouldNavigate, navigate, cafeInfo]);
 
   if (isLoading || reviewsQuery.isLoading) {

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useRef } from "react";
 import { throttle } from "lodash";
 import { ProfileHeader } from "@/entities/profile/ui";
 import { ReviewList } from "@/widgets/reviewList";
-import { useFavoriteApi } from "@/shared/api/favorite";
 import styles from "@/app/layout/mainLayout/MainLayout.module.scss";
 import { useNavigate, useParams } from "react-router-dom";
 import { useUserApi } from "@/shared/api/user/userApi";
@@ -11,32 +10,15 @@ const UserPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
   const [isScrolled, setIsScrolled] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const { favorites, isLoading: isFavLoading } = useFavoriteApi();
   const headerRef = useRef<HTMLDivElement>(null);
-  const [myId, setMyId] = useState<number | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const { getMyInfo } = useUserApi();
+  const { useMyInfo } = useUserApi();
+  const { data: myInfo } = useMyInfo();
 
-  //------- 차후 reactQuery 세션스토리지로 userId 가져오도록 수정 필요 ------
-  useEffect(() => {
-    const fetchUserData = async () => {
-      try {
-        const response = await getMyInfo();
-        setMyId(response.userId);
-        
-        if (response.userId === Number(id)) {
-          navigate("/mypage", { replace: true });
-        }
-      } catch (error) {
-        console.error("Failed to fetch user info:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchUserData();
-  }, [id, navigate]);
-  // -------------------------------------------------------
+  useEffect(()=> {
+    if (myInfo?.userId === Number(id)) {
+      navigate("/mypage", { replace: true });
+    } 
+  }, [myInfo]);
 
   useEffect(() => {
     const mainContent = document.querySelector(`.${styles.mainContent}`);
@@ -71,14 +53,6 @@ const UserPage = () => {
     mainContent.scrollTop = 309;
   };
 
-  if (isLoading || myId === null) {
-    return <div>로딩 중...</div>;
-  }
-
-  if (myId === Number(id)) {
-    return null;
-  }
-
   return (
     <div>
       <div ref={headerRef}>
@@ -88,17 +62,13 @@ const UserPage = () => {
         />
       </div>
       <div>
-        {isFavLoading ? (
-          <div>로딩 중...</div>
-        ) : (
-          <ReviewList 
-            type="user" 
-            params={{ 
-              limit: 10,
-              userId: Number(id),
-            }} 
-          />
-        )}
+        <ReviewList 
+          type="user" 
+          params={{ 
+            limit: 10,
+            userId: Number(id),
+          }}
+        />
       </div>
     </div>
   );

--- a/src/shared/api/hooks/useQuery.ts
+++ b/src/shared/api/hooks/useQuery.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey, useInfiniteQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, type UseMutationOptions, type UseQueryOptions, type QueryKey, useInfiniteQuery, UseSuspenseQueryOptions, useSuspenseQuery } from '@tanstack/react-query'
 // import { useMutation, useSuspenseQuery, type UseMutationOptions, type UseSuspenseQueryOptions, type QueryKey } from '@tanstack/react-query'
 import { apiInstance } from '@shared/api/base'
 import type { AxiosError } from 'axios'
@@ -12,16 +12,15 @@ export type ApiError = {
 export const useApiQuery = <TData>(
   queryKey: QueryKey,
   endpoint: string | (() => string),
-  options?: UseQueryOptions<TData, ApiError>
+  options?: UseSuspenseQueryOptions<TData, ApiError>
 ) => {
-  return useQuery<TData, ApiError>({
+  return useSuspenseQuery<TData, ApiError>({
     queryKey,
     queryFn: async () => {
       const url = typeof endpoint === "function" ? endpoint() : endpoint;
       const response = await apiInstance.get<TData>(url);
       return response
     },
-    throwOnError: true,
     ...options,
   })
 }

--- a/src/shared/ui/loading/Loading.module.scss
+++ b/src/shared/ui/loading/Loading.module.scss
@@ -1,0 +1,10 @@
+@use "/src/app/styles/abstracts/mixins";
+@use "/src/app/styles/abstracts/variables" as var;
+
+.loading {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center; 
+  height: 100vh;
+}

--- a/src/shared/ui/loading/Loading.tsx
+++ b/src/shared/ui/loading/Loading.tsx
@@ -1,0 +1,18 @@
+import Lottie from "lottie-react";
+import styles from "./Loading.module.scss";
+import spinnerAnimation from '@shared/assets/images/spinner.json';
+
+
+const Loading = () => {
+  return (
+    <div className={styles.loading}>
+      <Lottie
+        animationData={spinnerAnimation}
+        style={{ width: 40, height: 40 }}
+        loop={true}
+      />
+    </div>
+  );
+};
+
+export default Loading;


### PR DESCRIPTION
# 변경사항

## 발생한 문제
#### 1. 등록되지 않은 유저id로 유저페이지 접속시 아래와 같은 화면이 몇초동안 띄워졌다가 에러화면으로 변경됨
- api 응답 지연때문
![image](https://github.com/user-attachments/assets/d15d7880-9ae8-492c-9af5-3c4aca64ff57)

#### 2. useQuery를 이용한 api 호출은 로딩 ui가 구현되지 않은 상태

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
- 유저/마이 페이지 렌더링시(비동기 작업 지연시) 로딩 스피너 ui 띄우기
- React의 Suspense 컴포넌트를 이용한 로딩 컴포넌트 제작


## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
### 1. 마이/유저페이지 api요청방식 변경
- 일반 axios 사용한 요청에서 useQuery로 요청하도록 변경

### 2. Suspense를 이용한 로딩화면 구현
- useQuery의 비동기 작업(api 요청)이 끝나지 않아 Promise를 던지면, Suspense에서 이를 받아 로딩 ui를 띄움
- Suspense의 fallback 속성을 통해 로딩 ui 구축

#### Suspense 사용 예시
```typescript
import { Suspense } from "react";

<Route
  path="userpage/:id"
  element={
      <Suspense fallback={
        <Loading />                       // 커스텀한 로딩 ui
      }>
        <UserPage />
      </Suspense>
  }
``` 

####  Suspense를 사용하기 위한 useQuery 설정
- useQuery 대신 useSuspenseQuery를 사용합니다
```typescript
export const useApiQuery = <TData>(
  queryKey: QueryKey,
  endpoint: string | (() => string),
  options?: UseSuspenseQueryOptions<TData, ApiError>     //기존의 UseQueryOptions를 변경
) => {
  return useSuspenseQuery<TData, ApiError>({                      //기존의 useQuery를 변경
    queryKey,
    queryFn: async () => {
      const url = typeof endpoint === "function" ? endpoint() : endpoint;
      const response = await apiInstance.get<TData>(url);
      return response
    },
    ...options,
  })
}
``` 

## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. https://localhost:5173/userpage/9999 url에 접속했을때 로딩 화면이 떴다가 "서버에 문제가 발생했어요"가 뜨는지 확인
2. 마이페이지에 접속했을때 헤더,푸터 제외한 전체 ui에 로딩화면이 뜨는지 확인