### PR TITLE
style: 태그 사이즈 조정

### DIFF
--- a/src/entities/review/ui/reviewTag/ReviewTag.module.scss
+++ b/src/entities/review/ui/reviewTag/ReviewTag.module.scss
@@ -6,4 +6,10 @@
   background-color: var.$primitive-secondary-brown50;
   border-radius: var.$radius-radius-sm;
   @include mixins.apply-text-style(l_regular);
+  height: 24px;
+}
+
+.icon {
+  width: 15px;
+  height: 15px;
 }


### PR DESCRIPTION
# 변경사항
## 기능 설명
- 리뷰 목록의 태그 Chips 사이즈를 디자인에 맞게 수정

## 관련 이슈
- [노션 - 홈5 : 이미지 인디케이터 추가](https://www.notion.so/5-1a05086f3cd9805b81e8e4c335324fa2?pvs=4)

## 추가 설명
- 단일 이미지의 인디케이터 표시가 안되어서 해당 기능은 제외하고, 태그 사이즈만 수정 완료했습니다.