### PR TITLE
fix: 작성된 글자 수 색상 수정, 사진 추가 시 추가된 장수 변하지 않는 문제

### DIFF
--- a/src/pages/WriteReview.tsx
+++ b/src/pages/WriteReview.tsx
@@ -22,8 +22,7 @@ const WriteReview = () => {
   const location = useLocation();
   const { returnPath, setReturnPath } = useNavigationStore();
   const { draft, updateDraft, clearDraft } = useReviewDraftStore();
-  // draftReviewId를 명시적으로 전달
-  const { images, config } = usePhotoUploaderStore(draft.id!);
+  const { config } = usePhotoUploaderStore(draft.id!);
   const { createReview, isLoading } = useReviewApi();
   const { getCafe } = useCafeApi();
   const [isImageUploading, setIsImageUploading] = useState(false);
@@ -59,7 +58,7 @@ const WriteReview = () => {
       if (returnPath) {
         navigate(returnPath, { replace: true });
       } else {
-        navigate('/', { replace: true });
+        navigate("/", { replace: true });
       }
       return true;
     }
@@ -286,7 +285,7 @@ const WriteReview = () => {
             <div className={styles.reviewLabelContainer}>
               <span className={styles.reviewSubLabel}>상세 리뷰</span>
               <span className={styles.charCount}>
-                {draft.content?.length || 0} / 200자
+                <span>{draft.content?.length || 0}</span>&nbsp;/ 200자
               </span>
             </div>
           }
@@ -307,7 +306,7 @@ const WriteReview = () => {
             <div className={styles.reviewLabelContainer}>
               <span className={styles.reviewSubLabel}>사진 첨부</span>
               <span className={styles.photoCount}>
-                {images.length} / {config.maxCount}장
+                <span>{draft.imageIds?.length || 0}</span>&nbsp;/ {config.maxCount}장
               </span>
             </div>
           }

--- a/src/pages/styles/WriteReview.module.scss
+++ b/src/pages/styles/WriteReview.module.scss
@@ -56,6 +56,10 @@ $spacing: 32px; // 버튼 상단 여백
 .charCount {
   color: var.$semantic-text-icon-secondary;
   @include mixins.apply-text-style(b2_regular);
+
+  span:first-child {
+    color: #121212;
+  }
 }
 
 .reviewTextarea {
@@ -83,6 +87,10 @@ $spacing: 32px; // 버튼 상단 여백
   display: flex;
   justify-content: flex-end;
   margin: 4px 0;
+
+  span:first-child {
+    color: #121212;
+  }
 }
 
 .buttonOverlay {
@@ -148,7 +156,7 @@ $spacing: 32px; // 버튼 상단 여백
   margin-top: 16px;
   margin-bottom: 16px;
   width: 100%;
-  
+
   &.noMarginBottom {
     margin-bottom: 0;
   }


### PR DESCRIPTION
# 변경사항
## 기능 설명
- 리뷰 작성 페이지의 UI 개선사항 수정
  - 작성된 글자 수, 사진 수 카운트의 가독성 개선
  - 사진 업로드 시 첨부된 사진 수가 실시간으로 반영되도록 수정

## 구현 상세
### 1. 글자 수 카운트 UI 개선
- 현재 입력된 글자 수를 강조하기 위해 색상을 #121212로 변경
- CSS 모듈에서 `span:first-child` 선택자를 사용하여 현재 글자 수만 스타일 적용

### 2. 사진 첨부 수 표시 버그 수정
- 기존: `images` 배열의 길이를 직접 참조하여 첨부된 사진 수를 표시
- 변경: `draft.imageIds?.length`를 사용하여 실제 저장된 이미지 ID 개수를 표시

## 테스트 방법
1. 리뷰 작성 페이지에서 텍스트를 입력하고 글자 수 카운트 UI 확인
   - 현재 글자 수가 진한 색상으로 표시되는지 확인
2. 사진 첨부 기능 테스트
   - 사진 추가/삭제 시 첨부된 사진 수가 실시간으로 정확하게 업데이트되는지 확인