### PR TITLE
fix: Datepicker 날짜 스타일 변경으로 수직 정렬 문제 수정

### DIFF
--- a/src/widgets/datePicker/ui/DatePicker.module.scss
+++ b/src/widgets/datePicker/ui/DatePicker.module.scss
@@ -111,36 +111,43 @@
 
 .calendar {
   width: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.weekdays, .days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  width: 100%;
+  > div, button {
+    width: 100%;
+    aspect-ratio: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 }
 
 .weekdays {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
   margin-bottom: 10px;
-  text-align: center;
-}
-
-.weekday {
-  font-size: 14px;
-  color: #666;
-  padding: 5px;
 }
 
 .days {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
   gap: 5px;
 }
 
 .day {
+  width: 100%;
   aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: none;
   background: none;
   font-size: 16px;
   cursor: pointer;
   border-radius: 50%;
-  width: auto;
-  height: auto;
+  padding: 0;
   
   &:hover:not(:disabled) {
     background-color: #ff6b00;
@@ -173,4 +180,4 @@
     background-color: #ccc;
     cursor: not-allowed;
   }
-} 
+}


### PR DESCRIPTION
# 변경사항

## 기능 설명
DatePicker 컴포넌트에서 요일(weekdays)과 날짜(days) 간의 수직 정렬이 맞지 않는 문제를 해결했습니다.

### 기존 문제점
1. 요일과 날짜 열이 수직으로 어긋나는 현상
   - weekdays와 days의 그리드 셀 크기가 서로 달라 수직 정렬이 맞지 않음

## 구현 상세
### 1. 그리드 정렬 구조 통일
- 기존: weekdays와 days가 각각 다른 레이아웃 구조 사용
- 개선: 동일한 그리드 구조와 셀 크기 적용
  ```scss
  .weekdays, .days {
    display: grid;
    grid-template-columns: repeat(7, 1fr);
    width: 100%;
    > div, button {
      width: 100%;
      aspect-ratio: 1;
      display: flex;
      align-items: center;
      justify-content: center;
    }
  }
  ```

### 2. 일관된 셀 비율 적용
- 모든 셀(요일, 날짜)에 `aspect-ratio: 1` 적용으로 정사각형 비율 통일
- flex box로 내용 중앙 정렬

## 테스트 방법
1. 수직 정렬 테스트
   - 각 요일 헤더와 아래 날짜들이 정확히 수직으로 정렬되는지 확인
   - 날짜 선택 시에도 정렬이 유지되는지 확인