### PR TITLE
style: 카페정보 페이지 디자인 개선

### DIFF
--- a/src/entities/cafeInfo/ui/CafeInfoItem.module.scss
+++ b/src/entities/cafeInfo/ui/CafeInfoItem.module.scss
@@ -2,7 +2,7 @@
 @use "@app/styles/abstracts/variables" as var;
 
 .cafeInfoItem {
-  padding: 16px;
+  padding: 32px 16px;
 
   &__content {
     display: flex;
@@ -17,6 +17,7 @@
   &__name {
     color: var.$semantic-text-icon-primary;
     @include mixins.apply-text-style(t2_bold);
+    margin-bottom: 2px;
   }
 
   &__address {

--- a/src/pages/styles/CafeInfo.module.scss
+++ b/src/pages/styles/CafeInfo.module.scss
@@ -7,8 +7,7 @@
   }
   
   .ratingWrapper {
-    padding: 0 16px;
-    margin-top: 16px;
+    padding: 32px 16px 8px;
   }
   
   .ratingHeader {


### PR DESCRIPTION
# 변경사항

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
- 카페정보 페이지의 UI 가독성 향상
<img width="375" alt="카페정보to-be" src="https://github.com/user-attachments/assets/38f9b04a-07e5-43d0-a10a-87b20c05f8ac" />

## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
### 1. CafeInfo.module.scss 수정 코드
- ratingWrapper의 패딩 상단 32px, 하단 8px 추가
```typescript
  .ratingWrapper {
    padding: 32px 16px 8px;
  }
```

### 2. CafeInfoItem.module.scss 수정 코드
- CafeInfoItem의 패딩 상하 32px 추가
```typescript
.cafeInfoItem {
  padding: 32px 16px;
```
- 카페 이름 마진 하단 2px 추가하여 아래 주소 정보와 시각적으로 분리
```typescript
 &__name {
    color: var.$semantic-text-icon-primary;
    @include mixins.apply-text-style(t2_bold);
    margin-bottom: 2px;
  }
```

## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. 메인 페이지에 작성된 리뷰 중 장소 chip 선택하여 카페 정보 페이지 진입
2. 헤더와 카페 정보 사이의 간격이 반영되었는지 확인
3. 카페 정보와 divider 사이의 간격이 반영되었는지 확인
4. divider와 리뷰 텍스트 사이의 간격이 반영되었는지 확인
5. 별점 컴포넌트와 리뷰 카드의 사이의 간격이 반영되었는지 확인

## 관련이슈
<!-- 아래 항목들을 확인하고 체크해주세요 -->
- [노션링크](https://www.notion.so/2-1a05086f3cd980ffb729f9bc90952658?pvs=4)