### PR TITLE
style: 임시저장 모달 ui 디자인 개선

### DIFF
--- a/src/app/styles/vendors/_modal.scss
+++ b/src/app/styles/vendors/_modal.scss
@@ -22,36 +22,38 @@
   top: 50%;
   left: 50%;
   color: var.$semantic-text-icon-primary;
+  
   h1 {
     @include mixins.apply-text-style(b1_bold);
+    margin-bottom:2px;
   }
-  p {
-    @include mixins.apply-text-style(b2_regular);
-  }
-  h2.modal-subtitle {
+  
+  h2.modal-description {
     @include mixins.apply-text-style(b2_regular);
     color: var.$semantic-text-icon-primary;
-    margin-top: 4px;
   }
+
   .modal-btn-wrap {
     display: flex;
-    gap: 16px;
-
+    gap: 8px;
     margin-top: 16px;
-    @include mixins.apply-text-style(b2_bold);
+
     .modal-btn {
       width: 100%;
       height: 40px;
       border-radius: var.$radius-radius-md;
+      @include mixins.apply-text-style(b2_bold);
     }
-    .modal-btn-yes {
-      background: var.$semantic-background-button-default;
-      color: #fff;
-    }
+    
     .modal-btn-no {
       background: var.$semantic-background-primary;
       color: var.$semantic-text-icon-primary;
       border: 1px solid var.$semantic-border-secondary;
+    }
+
+    .modal-btn-yes {
+      background: var.$semantic-background-button-default;
+      color: #fff;
     }
   }
 }

--- a/src/entities/cafeInfo/ui/CafeInfoItem.module.scss
+++ b/src/entities/cafeInfo/ui/CafeInfoItem.module.scss
@@ -2,7 +2,7 @@
 @use "@app/styles/abstracts/variables" as var;
 
 .cafeInfoItem {
-  padding: 16px;
+  padding: 32px 16px;
 
   &__content {
     display: flex;
@@ -17,6 +17,7 @@
   &__name {
     color: var.$semantic-text-icon-primary;
     @include mixins.apply-text-style(t2_bold);
+    margin-bottom: 2px;
   }
 
   &__address {

--- a/src/pages/styles/CafeInfo.module.scss
+++ b/src/pages/styles/CafeInfo.module.scss
@@ -7,8 +7,7 @@
   }
   
   .ratingWrapper {
-    padding: 0 16px;
-    margin-top: 16px;
+    padding: 32px 16px 8px;
   }
   
   .ratingHeader {

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -31,11 +31,10 @@ const Modal: React.FC<ModalProps> = ({
       overlayClassName="modal-overlay"
     >
       <h1>{title}</h1>
-      {subTitle && <h2 className="modal-subtitle">{subTitle}</h2>}
-      {description && <p>{description}</p>}
+      {description && <h2 className="modal-description">{description}</h2>}
       <div className="modal-btn-wrap">
-        <Button {...primaryButton} />
         <Button {...secondaryButton} />
+        <Button {...primaryButton} />
       </div>
     </ReactModal>
   );


### PR DESCRIPTION
# 변경사항

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
리뷰 작성하다가 '뒤로가기'버튼 눌렀을 때 (임시저장 할 때) 뜨는 모달 수정
- UI 가독성 향상을 위한 간격 조정
- UX관점을 고려하여 CTA 버튼의 위치 변경
<img width="375" alt="임시저장_02_popup" src="https://github.com/user-attachments/assets/1f9fc531-389d-4018-b1ce-a59a09650072" />

## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
### [UI 가독성 향상]
### 1. 버튼 내 텍스트가 bold가 아닌 regular로 적용되어있던 문제
**기존:** 
- “작성 중인 내용은 임시 저장되어 다음에 이어서 작성할 수 있어요”가 p로 설정되어 있었음 `{description && <p>{description}</p>}`
- p의 스타일은 b2_regular `p {@include mixins.apply-text-style(b2_regular);}`
- “작성 중인 내용은 임시 저장되어 다음에 이어서 작성할 수 있어요” (`{description && <p>{description}</p>}`)와 버튼(`import Button from "../button/ui/Button";`) 내 텍스트 p가 모두 b2_regular 값으로 적용되어 있던 상태

**수정:** 
- subTitle 존재 하지 않으므로 정의하지 않음
- 대신 description이 존재하므로 h2 HTML 태그를 subTitle가 아닌 description에 사용하도록 코드 수정
```typescript
return (
    <ReactModal
      isOpen={isOpen}
      onRequestClose={onClose}
      className="modal-content"
      overlayClassName="modal-overlay"
    >
      <h1>{title}</h1>
      {description && <h2 className="modal-subtitle">{description}</h2>}
      <div className="modal-btn-wrap">
        <Button {...secondaryButton} />
        <Button {...primaryButton} />
      </div>
    </ReactModal>
  );
```
- 버튼 내 p의 폰트를 modal-btn 클래스 내에서  b2_bold로 정의
```typescript
.modal-btn {
      width: 100%;
      height: 40px;
      border-radius: var.$radius-radius-md;
      @include mixins.apply-text-style(b2_bold);
    }
```

### 2. 세부 간격 조정
- 상위 제목 아래 마진 2px 추가하여 설명글과 시각적으로 분리
```typescript
h1 {
    @include mixins.apply-text-style(b1_bold);
    margin-bottom:2px;
  }
```
- 버튼 사이의 간격 16px에서 8px으로 수정 
```typescript
.modal-btn-wrap {
    display: flex;
    gap: 8px;
    margin-top: 16px;
```

### [UX관점을 고려하여 CTA 버튼의 위치 변경]
### 1. CTA 버튼의 위치 변경 (‘나가기’버튼을 오른쪽으로)
사람들은 일반적으로 웹 페이지를 볼 때 왼쪽 상단에서 시작하여 오른쪽으로 이동하기 때문에 CTA 버튼이 오른쪽에 있으면 사용자가 정보를 처리한 후 즉시 다음 액션으로 연결될 수 있어 사용자 여정을 효율적으로 만들어줌
- 중요한 CTA 버튼을 우측으로 배치하기 위해 secondaryButton 코드를 앞순으로 수정
```typescript
      <div className="modal-btn-wrap">
        <Button {...secondaryButton} />
        <Button {...primaryButton} />
```

## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. 메인화면에서 플로팅 버튼을 통해 장소 검색 후 리뷰 작성 화면 진입
2. 뒤로 가기 버튼을 눌렀을 때 뜨는 모달 확인
- 요소들 간 간격 확인
- 버튼 내 폰트 굵기 bold로 바뀌었는지 확인
- CTA 버튼의 위치 오른쪽으로 바뀌었는지 확인

## 관련 이슈
<!-- 관련된 이슈 번호를 링크해주세요 -->
- [노션링크: 임시저장1 - 간격 수정](https://www.notion.so/1-1a05086f3cd98065a141f5583374966f?pvs=4)