### PR TITLE
fix: subTitle을 제거하고 사용하는 부분들 description으로 치환

### DIFF
--- a/src/entities/review/ui/reviewMore/ReviewMore.tsx
+++ b/src/entities/review/ui/reviewMore/ReviewMore.tsx
@@ -84,7 +84,7 @@ const ReviewMore = ({
           isOpen={isModalOpen}
           onClose={closeModal}
           title="내가 작성한 리뷰를 삭제하시겠어요?"
-          subTitle="삭제된 글은 복구되지 않아요."
+          description="삭제된 글은 복구되지 않아요."
           primaryButton={{
             text: "취소",
             onClick: () => {

--- a/src/pages/CafeSearch.tsx
+++ b/src/pages/CafeSearch.tsx
@@ -285,7 +285,7 @@ const CafeSearch = () => {
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
         title={`${selectedCafe?.cafe.name}의 리뷰를 이어서 작성하시겠어요?`}
-        subTitle="해당 카페의 임시 저장된 리뷰가 있어요."
+        description="해당 카페의 임시 저장된 리뷰가 있어요."
         primaryButton={{
           text: "새로 작성하기",
           onClick: () => {

--- a/src/shared/ui/modal/Modal.tsx
+++ b/src/shared/ui/modal/Modal.tsx
@@ -8,7 +8,6 @@ interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   title: string;
-  subTitle?: string;
   description?: string;
   primaryButton: ButtonProps;
   secondaryButton: ButtonProps;
@@ -18,7 +17,6 @@ const Modal: React.FC<ModalProps> = ({
   isOpen,
   onClose,
   title,
-  subTitle,
   description,
   primaryButton,
   secondaryButton,


### PR DESCRIPTION
# 수정사항
- [PR#144](https://github.com/cafeLogProject/frontend/pull/144)에서 발견한 subtitle, description이 사실상 같고 같이 사용되는 부분이 없어 description만 사용하도록 수정합니다.