### PR TITLE
fix: SearchBar 이전 검색어 남아있는 문제, Navbar -> Floating 라우팅 시 이전 값 문제

### DIFF
--- a/src/features/search/ui/SearchBar.tsx
+++ b/src/features/search/ui/SearchBar.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { FormEvent, useState, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useNavigationStore } from '@shared/store/useNavigationStore';
 import searchIcon from '@shared/assets/images/search/search.svg';
 import clearIcon from '@shared/assets/images/search/search-clear.svg';
@@ -7,8 +7,14 @@ import styles from './SearchBar.module.scss';
 
 export const SearchBar = ({ initialValue = '' }: { initialValue?: string }) => {
   const [value, setValue] = useState(initialValue);
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { isFromFooter } = useNavigationStore();
+
+  useEffect(() => {
+    const query = searchParams.get("name");
+    setValue(query || '');
+  }, [isFromFooter, searchParams]);
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -194,22 +194,24 @@ const Search = () => {
     }
   }, [shouldNavigate, navigate]);
 
-  // 검색어와 탭이 변경될 때마다 해당 탭의 검색 실행
+  // 검색어와 탭이 변경될 때마다 초기화
   useEffect(() => {
     const query = searchParams.get("name");
-    if (!query) return;
-
-    switch (activeTab) {
-      case "cafe":
-        // TODO: 프로필 검색 결과 초기화
-        searchByName(query).then(setCafes);
-        break;
-      case "profile":
-        // 카페 검색 결과 초기화
-        setCafes([]);
-        // TODO: 프로필 검색 API 호출
-        break;
-    }
+  
+    const fetchCafes = async () => {
+      setCafes([]);
+      if (!isFromFooter || activeTab === "cafe") {
+        try {
+          const results = await searchByName(query);
+          setCafes(results);
+        } catch (error) {
+          console.error("카페 검색 중 오류 발생:", error);
+          setCafes([]);
+        }
+      }
+    };
+  
+    fetchCafes();
   }, [searchParams, activeTab]);
 
   useEffect(() => {
@@ -232,11 +234,12 @@ const Search = () => {
 
   const ProfileSearchResults = ({ nickname }: { nickname: string }) => {
     const { data: users, error } = useSearchUsers(nickname);
-  
-    const handleFollowChange = (userId: number) => (type: "follow" | "unfollow") => {
-      console.log(`User ${userId} ${type}`);
-    };
-  
+
+    const handleFollowChange =
+      (userId: number) => (type: "follow" | "unfollow") => {
+        console.log(`User ${userId} ${type}`);
+      };
+
     if (error) {
       return (
         <div className={styles.errorContainer}>
@@ -244,7 +247,7 @@ const Search = () => {
         </div>
       );
     }
-  
+
     if (!users || users.length === 0) {
       return (
         <NoContent
@@ -254,12 +257,12 @@ const Search = () => {
         />
       );
     }
-  
+
     return (
-      <UserList 
-        users={users} 
+      <UserList
+        users={users}
         onUserSelect={handleUserSelect}
-        renderFollowButton={(user) => (
+        renderFollowButton={(user) =>
           user.isFollow !== 2 && (
             <FollowBtn
               onChange={handleFollowChange(user.userId)}
@@ -268,7 +271,7 @@ const Search = () => {
               size="small"
             />
           )
-        )}
+        }
       />
     );
   };

--- a/src/shared/api/cafe/cafeSearch.ts
+++ b/src/shared/api/cafe/cafeSearch.ts
@@ -1,6 +1,7 @@
 import { useApi, ApiError } from "@shared/api/hooks/useApi";
 import type { INaverLocalApiResponse, ICafeDescription } from '@shared/api/cafe/types';
 import { CafeMapper } from '@shared/api/cafe/mapper/cafeMapper';
+import { useCallback } from "react";
 
 interface SearchResponse {
   items: INaverLocalApiResponse[]
@@ -21,7 +22,7 @@ export const useCafeSearch = (): CafeSearchHook => {
     get 
   } = useApi<ICafeDescription[]>();
 
-  const searchByName = async (name: string | null) => {
+  const searchByName = useCallback(async (name: string | null) => {
     if (!name) {
       return [];
     }
@@ -48,7 +49,7 @@ export const useCafeSearch = (): CafeSearchHook => {
       console.error('카페 검색 중 오류 발생:', error);
       throw error;
     }
-  };
+  }, [get]);
 
   return {
     cafes: data || [],


### PR DESCRIPTION
## 수정사항
- SearchBar에서 이전 검색어가 남아있는 문제 해결
- Navbar(검색)에서 Floating Button(리뷰작성)으로 라우팅 시 이전 값이 유지되는 문제 수정

## 상세 내용
- SearchBar 컴포넌트에 useEffect를 추가하여 isFromFooter 상태 변경 시 검색어 초기화
- URL 쿼리 파라미터와 검색창 상태를 동기화하도록 useSearchParams 훅 활용
- 탭 전환 및 Navbar <-> Floating 전환 시 이전 검색 결과가 남지 않도록 초기화
- 카페 검색 함수를 useCallback으로 감싸 불필요한 리렌더링 방지

## 테스트 방법
- Navbar <-> Floating 전환 시 주소창, 검색창 값 초기화 및 검색 작동 확인