### PR TITLE
style: 바텀시트 padding, 태그필터 버튼과 태그 사이 간격 수정

### DIFF
--- a/src/entities/review/ui/reviewFilter/ReviewFilter.module.scss
+++ b/src/entities/review/ui/reviewFilter/ReviewFilter.module.scss
@@ -38,7 +38,7 @@
 .bottomSheetButtons {
   display: flex;
   gap: 8px;
-  margin-top: 20px;
+  margin-top: 32px;
 
   .resetButton {
     flex: 0.675;

--- a/src/shared/ui/bottomSheet/BottomSheet.module.scss
+++ b/src/shared/ui/bottomSheet/BottomSheet.module.scss
@@ -19,7 +19,7 @@
   max-width: 600px;
   background-color: white;
   border-radius: 16px 16px 0 0;
-  padding: 12px 24px 24px 24px;
+  padding: 12px 16px 24px 16px;
   z-index: 101;
   animation: slideUp 0.3s ease-out;
   max-height: 80vh;


### PR DESCRIPTION
## 수정사항
- bottom sheet의 padding 값을 16으로 수정
- 마지막 chip들과 버튼 사이의 간격을 32로 수정

## 관련이슈
- [홈4 : 간격 수정(노션)](https://www.notion.so/4-1a05086f3cd98003b4d4f43331e6285c?pvs=4)