### PR TITLE
style: 리뷰작성 페이지 스타일 수정

### DIFF
--- a/src/pages/WriteReview.tsx
+++ b/src/pages/WriteReview.tsx
@@ -211,7 +211,7 @@ const WriteReview = () => {
 
         <InputWrapper
           label={<span className={styles.mainLabel}>언제 방문했나요?</span>}
-          className={styles.inputLabel}
+          className={`${styles.inputLabel} ${styles.firstInputWrapper}`}
           isRequired={true}
           error={
             !draft.visitDate &&

--- a/src/pages/WriteReview.tsx
+++ b/src/pages/WriteReview.tsx
@@ -205,7 +205,7 @@ const WriteReview = () => {
       onBackClick={handleBackClick} // BackButton 클릭 핸들러 추가
     >
       <div className={styles.container}>
-        <div className="selected-cafe">
+        <div className={styles.stickySelectedCafe}>
           <CafeListItem {...draft.cafe} onSelect={() => {}} />
         </div>
 

--- a/src/pages/WriteReview.tsx
+++ b/src/pages/WriteReview.tsx
@@ -252,6 +252,8 @@ const WriteReview = () => {
             onChange={handleRatingChange}
             showRatingText={true}
             rootClassName={`${styles.starRatingContainer} ${
+              draft.rating > 0 ? styles.expanded : ""
+            } ${
               !draft.rating &&
               (draft.tags.menu?.length > 0 || draft.tags.interior?.length > 0)
                 ? styles.errorInput
@@ -306,7 +308,8 @@ const WriteReview = () => {
             <div className={styles.reviewLabelContainer}>
               <span className={styles.reviewSubLabel}>사진 첨부</span>
               <span className={styles.photoCount}>
-                <span>{draft.imageIds?.length || 0}</span>&nbsp;/ {config.maxCount}장
+                <span>{draft.imageIds?.length || 0}</span>&nbsp;/{" "}
+                {config.maxCount}장
               </span>
             </div>
           }

--- a/src/pages/styles/WriteReview.module.scss
+++ b/src/pages/styles/WriteReview.module.scss
@@ -16,6 +16,10 @@ $spacing: 32px; // 버튼 상단 여백
     color: #121212;
   }
 
+  .firstInputWrapper {
+    margin-top: 32px;
+  }
+  
   .tagContainer {
     display: flex;
     flex-direction: column;
@@ -143,9 +147,11 @@ $spacing: 32px; // 버튼 상단 여백
 }
 
 .starRatingContainer {
+  height: 80px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   width: 100%;
   background-color: #f9f8f6;
   border-radius: 8px;

--- a/src/pages/styles/WriteReview.module.scss
+++ b/src/pages/styles/WriteReview.module.scss
@@ -30,6 +30,13 @@ $spacing: 32px; // 버튼 상단 여백
   }
 }
 
+.stickySelectedCafe {
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  background-color: white;
+}
+
 .tagSection {
   h3 {
     font-size: 14px;

--- a/src/pages/styles/WriteReview.module.scss
+++ b/src/pages/styles/WriteReview.module.scss
@@ -162,12 +162,19 @@ $spacing: 32px; // 버튼 상단 여백
   width: 100%;
   background-color: #f9f8f6;
   border-radius: 8px;
+
+  gap: 0px;
+  padding: 0;
+
+  &.expanded {
+    height: 100px;
+  }
 }
 
 .starRatingStars {
   --stars-gap: 8px;
-  margin-top: 16px;
-  margin-bottom: 16px;
+  // margin-top: 16px;
+  // margin-bottom: 16px;
   width: 100%;
 
   &.noMarginBottom {

--- a/src/widgets/datePicker/ui/DatePicker.module.scss
+++ b/src/widgets/datePicker/ui/DatePicker.module.scss
@@ -1,4 +1,6 @@
 @use '@shared/ui/input/Input.module.scss';
+@use "@app/styles/abstracts/mixins";
+@use "/src/app/styles/abstracts/variables" as var;
 
 .inputContainer {
   position: relative;
@@ -17,7 +19,12 @@
   padding-right: 32px;
   border-radius: 8px;
   background-color: #F9F8F6;
-  color: #374151;
+  &::placeholder {
+    @include mixins.apply-text-style(b1_regular);
+    color: var.$primitive-secondary-brown500;
+  }
+  @include mixins.apply-text-style(b1_regular);
+  color: var.$primitive-secondary-brown500;
   outline: none;
   border: none;
   
@@ -35,8 +42,8 @@
 .calendarIcon {
   position: absolute;
   right: 8px;
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   color: #9CA3AF;
   pointer-events: none;
 }

--- a/src/widgets/datePicker/ui/DatePicker.module.scss
+++ b/src/widgets/datePicker/ui/DatePicker.module.scss
@@ -24,7 +24,7 @@
     color: var.$primitive-secondary-brown500;
   }
   @include mixins.apply-text-style(b1_regular);
-  color: var.$primitive-secondary-brown500;
+  color: var.$semantic-text-icon-primary;
   outline: none;
   border: none;
   

--- a/src/widgets/starRating/ui/StarIcon.tsx
+++ b/src/widgets/starRating/ui/StarIcon.tsx
@@ -3,7 +3,7 @@ import StarFilled from '@shared/assets/images/star-rating/star-filled.svg';
 import { StarIconProps } from '../types/types';
 import styles from './StarRating.module.scss';
 
-export const StarIcon = ({ filled, size = 36, onClick, onMouseEnter, onMouseLeave }: StarIconProps) => (
+export const StarIcon = ({ filled, size = 40, onClick, onMouseEnter, onMouseLeave }: StarIconProps) => (
   <img 
     src={filled ? StarFilled : StarEmpty}
     alt="star"

--- a/src/widgets/starRating/ui/StarRating.module.scss
+++ b/src/widgets/starRating/ui/StarRating.module.scss
@@ -27,8 +27,8 @@
 }
 
 .star {
-  width: 36px;
-  height: 36px;
+  width: 40px;
+  height: 40px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
@@ -51,13 +51,12 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 8px;
   gap: 4px;
 }
 
 .ratingValue {
   @include mixins.apply-text-style(b2_bold);
-  margin-top: 2px;
-  margin-bottom: 16px;
   
   &.low {
     color: var.$primitive-secondary-brown500;

--- a/src/widgets/starRating/ui/StarRating.tsx
+++ b/src/widgets/starRating/ui/StarRating.tsx
@@ -38,7 +38,7 @@ export const StarRating = ({
   onChange,
   showRatingText = false,
   showRatingValue = false,
-  size = 36,
+  size = 40,
   rootClassName,
   starsContainerClassName,
   ratingTextClassName,


### PR DESCRIPTION
## 수정사항
- 카페정보와 "언제 방문했나요?" 사이 간격을 32px로 수정
- 날짜 선택 필드의 placeholder 스타일을 적절한 믹스인과 variable로 변경
- 캘린더 아이콘의 크기 24 x 24px로 증가
- 별점 선택 필드의 높이 80px로 증가
- 카페정보를 sticky, z-index 설정으로 항상 상단에 고정
- 날짜 선택 날짜의 텍스트 컬러 수정
- 별점 컴포넌트 선택 시 높이 증가(100px), 별 크기 증가(40px), 컴포넌트 내부 간격 조정

## 관련이슈
- [리뷰작성4 : 간격 수정(노션)](https://www.notion.so/4-1a05086f3cd980a5892cdb2c1f0a593b?pvs=4)
- [리뷰작성6 : 검색 text field 내 text 수정, 요소 간 간격 수정(노션)](https://www.notion.so/6-text-field-text-1a05086f3cd980999c7ddc4998ee2701?pvs=4)